### PR TITLE
GH-283 Add file64 param to InstallPackageOverride

### DIFF
--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -3,7 +3,8 @@ param(
   [string] $packageName, 
   [string] $fileType = 'exe',
   [string] $silentArgs = '',
-  [string] $file,
+  [alias("fileFullPath")][string] $file,
+  [alias("fileFullPath64")][string] $file64,
   $validExitCodes = @(0)
 )
     Wait-ForMSIEXEC


### PR DESCRIPTION
Fixes issue #283 by adding the missing file64 parameter to the Install-ChocolateyInstallPackage override as referenced by https://github.com/mwrock/boxstarter/issues/283#issuecomment-352024589.  Otherwise, packages that were attempting to use this newer parameter for 64-bit installs were always installed as 32-bit when using Boxstarter.  