### PR TITLE
(GH-344) isDownloaded lies sometimes

### DIFF
--- a/Boxstarter.WinConfig/Install-WindowsUpdate.ps1
+++ b/Boxstarter.WinConfig/Install-WindowsUpdate.ps1
@@ -90,16 +90,12 @@ Install-WindowsUpdate -GetUpdatesFromMS:`$$GetUpdatesFromMS -AcceptEula:`$$Accep
                 }
 
                 $Result= $null
-                if ($update.isDownloaded -eq "true" -and ($update.InstallationBehavior.CanRequestUserInput -eq $false )) {
-                    Out-BoxstarterLog " * $($update.title) already downloaded"
+                if ($update.InstallationBehavior.CanRequestUserInput -eq $false ) {
+                    Download-Update $update
                     $result = install-Update $update $currentCount $totalUpdates
                 }
-                elseif($update.InstallationBehavior.CanRequestUserInput -eq $true) {
-                    Out-BoxstarterLog " * $($update.title) Requires user input and will not be downloaded"
-                }
                 else {
-                    Download-Update $update
-                    $result = Install-Update $update $currentCount $totalUpdates
+                    Out-BoxstarterLog " * $($update.title) Requires user input and will not be downloaded"
                 }
             }
 


### PR DESCRIPTION
At least on 1709 and 1803 pro/enterprise right after clean installation on this simple test https://raw.githubusercontent.com/tetatetit/mybox/master/test.ps1 (the key nuance is "Notify for download and auto install" AUOptions in Windows Update policy which can be set via gpedit.msc "Computer Configuration\Administrative Templates\Windows Components\Windows Update\Configure Automatic Updates"): Result - last update is ever impossible to install via Install-WindowsUpdate but infinite reboot loop instead