### PR TITLE
(GH-324) ensure chocolatey.dll and its deps are packaged in the remoting zip during package task

### DIFF
--- a/BuildScripts/default.ps1
+++ b/BuildScripts/default.ps1
@@ -25,7 +25,7 @@ properties {
 Task default -depends Build
 Task Build -depends Build-Clickonce, Build-Web, Install-ChocoLib, Test, Package
 Task Deploy -depends Build, Deploy-DownloadZip, Deploy-Bootstrapper, Publish-Clickonce, Update-Homepage -description 'Versions, packages and pushes to MyGet'
-Task Package -depends Clean-Artifacts, Version-Module, Pack-NuGet, Create-ModuleZipForRemoting, Package-DownloadZip -description 'Versions the psd1 and packs the module and example package'
+Task Package -depends Clean-Artifacts, Version-Module, Install-ChocoLib, Create-ModuleZipForRemoting, Pack-NuGet, Package-DownloadZip -description 'Versions the psd1 and packs the module and example package'
 Task Push-Public -depends Push-Chocolatey, Push-Github, Publish-Web
 Task All-Tests -depends Test, Integration-Test
 Task Quick-Deploy -depends Build-Clickonce, Build-web, Package, Deploy-DownloadZip, Deploy-Bootstrapper, Publish-Clickonce, Update-Homepage


### PR DESCRIPTION
fixes #324 by ensuring that the package step always pulls the choco dll and its deps before building the remoting zip and also before packing the nugets.

If you run `build package` before this PR in a clean space with no boxstarter.zip, the generated zip will not have the chocolatey.dll AND the nuget will not include the boxstarter.zip. With this PR, the `boxstarter.chocolatey.nupkg` should include the `boxstarter.zip` which should include the `chocolatey.dll` and log4net.

This only worked before because of a particular workflow I had with testing that does not necessarily make sense now.

Signed-off-by: mwrock <matt@mattwrock.com>