### PR TITLE
(GH-387) Set page file

### DIFF
--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
@@ -1,4 +1,4 @@
 Resolve-Path $PSScriptRoot\*.ps1 |
     % { . $_.ProviderPath }
 
-Export-ModuleMember Disable-UAC, Enable-UAC, Get-UAC, Disable-InternetExplorerESC, Disable-GameBarTips, Get-ExplorerOptions, Set-TaskbarSmall, Install-WindowsUpdate, Move-LibraryDirectory, Enable-RemoteDesktop, Set-ExplorerOptions, Get-LibraryNames, Update-ExecutionPolicy, Enable-MicrosoftUpdate, Disable-MicrosoftUpdate, Set-StartScreenOptions, Set-CornerNavigationOptions, Set-WindowsExplorerOptions, Set-TaskbarOptions, Disable-BingSearch
+Export-ModuleMember Disable-UAC, Enable-UAC, Get-UAC, Disable-InternetExplorerESC, Disable-GameBarTips, Get-ExplorerOptions, Set-TaskbarSmall, Install-WindowsUpdate, Move-LibraryDirectory, Enable-RemoteDesktop, Set-ExplorerOptions, Get-LibraryNames, Update-ExecutionPolicy, Enable-MicrosoftUpdate, Disable-MicrosoftUpdate, Set-StartScreenOptions, Set-CornerNavigationOptions, Set-WindowsExplorerOptions, Set-TaskbarOptions, Disable-BingSearch, Set-PageFile

--- a/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
+++ b/Boxstarter.WinConfig/Boxstarter.WinConfig.psm1
@@ -1,4 +1,4 @@
 Resolve-Path $PSScriptRoot\*.ps1 |
     % { . $_.ProviderPath }
 
-Export-ModuleMember Disable-UAC, Enable-UAC, Get-UAC, Disable-InternetExplorerESC, Disable-GameBarTips, Get-ExplorerOptions, Set-TaskbarSmall, Install-WindowsUpdate, Move-LibraryDirectory, Enable-RemoteDesktop, Set-ExplorerOptions, Get-LibraryNames, Update-ExecutionPolicy, Enable-MicrosoftUpdate, Disable-MicrosoftUpdate, Set-StartScreenOptions, Set-CornerNavigationOptions, Set-WindowsExplorerOptions, Set-TaskbarOptions, Disable-BingSearch, Set-PageFile
+Export-ModuleMember Disable-UAC, Enable-UAC, Get-UAC, Disable-InternetExplorerESC, Disable-GameBarTips, Get-ExplorerOptions, Set-TaskbarSmall, Install-WindowsUpdate, Move-LibraryDirectory, Enable-RemoteDesktop, Set-ExplorerOptions, Get-LibraryNames, Update-ExecutionPolicy, Enable-MicrosoftUpdate, Disable-MicrosoftUpdate, Set-StartScreenOptions, Set-CornerNavigationOptions, Set-WindowsExplorerOptions, Set-TaskbarOptions, Disable-BingSearch, Set-BoxstarterPageFile

--- a/Boxstarter.WinConfig/Set-BoxstarterPageFile.ps1
+++ b/Boxstarter.WinConfig/Set-BoxstarterPageFile.ps1
@@ -53,8 +53,7 @@ Function Set-BoxstarterPageFile {
         [Parameter()]
         [Switch]$Reboot
     )
-Begin {}
-Process {
+
     If($PSCmdlet.ShouldProcess("Setting the virtual memory page file size")) {
         $DriveLetter | ForEach-Object -Process {
             $DL = $_
@@ -115,8 +114,6 @@ Process {
         }
     }
 }
-End {}
-}
  
 Function Set-PageFileSize {
 [CmdletBinding()]
@@ -134,8 +131,6 @@ Param(
         [ValidateRange(0,[int32]::MaxValue)]
         [Int32]$MaximumSize
 )
-Begin {}
-Process {
     #The AutomaticManagedPagefile property determines whether the system managed pagefile is enabled. 
     #This capability is not available on windows server 2003,XP and lower versions.
     #Only if it is NOT managed by the system and will also allow you to change these.
@@ -182,6 +177,4 @@ Process {
     } catch {
         Write-Warning "Pagefile configuration changed on computer '$Env:COMPUTERNAME'. The computer must be restarted for the changes to take effect."
     }
-}
-End {}
 }

--- a/Boxstarter.WinConfig/Set-BoxstarterPageFile.ps1
+++ b/Boxstarter.WinConfig/Set-BoxstarterPageFile.ps1
@@ -1,7 +1,7 @@
 #Andrea Dalle Vacche
 #Requires -Version 3.0
  
-Function Set-PageFile {
+Function Set-BoxstarterPageFile {
 <#
     .SYNOPSIS
         Set-PageFile is an advanced function which can be used to adjust virtual memory page file size.

--- a/Boxstarter.WinConfig/Set-BoxstarterPageFile.ps1
+++ b/Boxstarter.WinConfig/Set-BoxstarterPageFile.ps1
@@ -4,23 +4,23 @@
 Function Set-BoxstarterPageFile {
 <#
     .SYNOPSIS
-        Set-PageFile is an advanced function which can be used to adjust virtual memory page file size.
+        This can be used to manage the Windows page file.
     .DESCRIPTION
-        Set-PageFile is an advanced function which can be used to adjust virtual memory page file size.
-    .PARAMETER  <InitialSize>
-        Setting the paging file's initial size.
-    .PARAMETER  <MaximumSize>
-        Setting the paging file's maximum size.
-    .PARAMETER  <DriveLetter>
-        Specifies the drive letter you want to configure.
-    .PARAMETER  <SystemManagedSize>
-        Allow Windows to manage page files on this computer.
-    .PARAMETER  <None>        
-        Disable page files setting.
-    .PARAMETER  <Reboot>      
+        This can be used to manage the Windows page file.
+    .PARAMETER InitialSize
+        Initial size of the page file.
+    .PARAMETER MaximumSize
+        Maximum size of the page file.
+    .PARAMETER DriveLetter
+        The drive used for the holding the page file.
+    .PARAMETER SystemManagedSize
+        Allow Windows to manage the page files.
+    .PARAMETER None        
+        Disable the use of the page file.
+    .PARAMETER Reboot      
         Reboot the computer so that configuration changes take effect.
-    .PARAMETER  <AutoConfigure>
-        Automatically configure the initial size and maximumsize.
+    .PARAMETER AutoConfigure
+        Automatically configure the initial size and maximum size.
     .EXAMPLE
         C:\PS> Set-PageFile -InitialSize 1024 -MaximumSize 4096 -DriveLetter "C","D"
  
@@ -32,9 +32,6 @@ Function Set-BoxstarterPageFile {
         C:\pagefile.sys            1024            4096
         D:\pagefile.sys            1024            4096
         E:\pagefile.sys            2048            4096
-    .LINK
-        Get-WmiObject
-        http://technet.microsoft.com/library/hh849824.aspx
 #>
     [cmdletbinding(SupportsShouldProcess,DefaultParameterSetName="SetPageFileSize")]
     Param

--- a/Boxstarter.WinConfig/Set-BoxstarterPageFile.ps1
+++ b/Boxstarter.WinConfig/Set-BoxstarterPageFile.ps1
@@ -4,24 +4,22 @@ Function Set-BoxstarterPageFile {
         This can be used to manage the Windows page file.
     .DESCRIPTION
         This can be used to manage the Windows page file.
-    .PARAMETER InitialSize
+    .PARAMETER InitialSizeMB
         Initial size of the page file.
-    .PARAMETER MaximumSize
+    .PARAMETER MaximumSizeMB
         Maximum size of the page file.
     .PARAMETER DriveLetter
         The drive used for the holding the page file.
     .PARAMETER SystemManagedSize
         Allow Windows to manage the page files.
-    .PARAMETER None        
+    .PARAMETER Disable
         Disable the use of the page file.
-    .PARAMETER Reboot      
-        Reboot the computer so that configuration changes take effect.
     .EXAMPLE
-        C:\PS> Set-PageFile -InitialSize 1024 -MaximumSize 4096 -DriveLetter "C","D"
- 
+        C:\PS> Set-PageFile -InitialSizeMB 1024 -MaximumSizeMB 4096 -DriveLetter "C","D"
+
         Execution Results: Set page file size on "C" successful.
         Execution Results: Set page file size on "D:" successful.
- 
+
         Name            InitialSize(MB) MaximumSize(MB)
         ----            --------------- ---------------
         C:\pagefile.sys            1024            4096
@@ -33,148 +31,134 @@ Function Set-BoxstarterPageFile {
     (
         [Parameter(Mandatory,ParameterSetName="SetPageFileSize")]
         [Alias('is')]
-        [Int32]$InitialSize,
- 
+        [Int32]$InitialSizeMB,
+
         [Parameter(Mandatory,ParameterSetName="SetPageFileSize")]
         [Alias('ms')]
-        [Int32]$MaximumSize,
- 
+        [Int32]$MaximumSizeMB,
+
         [Parameter(Mandatory)]
         [Alias('dl')]
         [ValidatePattern('^[A-Z]$')]
         [String[]]$DriveLetter,
- 
-        [Parameter(Mandatory,ParameterSetName="None")]
-        [Switch]$None,
- 
+
+        [Parameter(Mandatory,ParameterSetName="Disable")]
+        [Switch]$Disable,
+
         [Parameter(Mandatory,ParameterSetName="SystemManagedSize")]
-        [Switch]$SystemManagedSize,
- 
-        [Parameter()]
-        [Switch]$Reboot
+        [Switch]$SystemManagedSize
     )
 
-    If($PSCmdlet.ShouldProcess("Setting the virtual memory page file size")) {
-        $DriveLetter | ForEach-Object -Process {
-            $DL = $_
-            $PageFile = $Vol = $null
-            try {
-                $Vol = Get-WmiObject -Class CIM_StorageVolume -Filter "Name='$($DL):\\'" -ErrorAction Stop
-            } catch {
-                Write-Warning -Message "Failed to find the DriveLetter $DL specified"
-                return
+    Function Set-PageFileSize {
+        [CmdletBinding()]
+        Param(
+            [Parameter(Mandatory)]
+            [ValidatePattern('^[A-Z]$')]
+            [String]$DriveLetter,
+
+            [Parameter(Mandatory)]
+            [ValidateRange(0, [int32]::MaxValue)]
+            [Int32]$InitialSizeMB,
+
+            [Parameter(Mandatory)]
+            [ValidateRange(0, [int32]::MaxValue)]
+            [Int32]$MaximumSizeMB
+        )
+        # There is a bug in earlier versions of PowerShell when using put() in
+        # that it would throw an exception but actually make the change. The
+        # EnableAllPrivileges switch for Get-WmiObject seems to stop this
+        # exception being thrown.
+        $pfStatus = Get-WmiObject -Class Win32_ComputerSystem -EnableAllPrivileges -ErrorAction Stop
+        if ($pfStatus.AutomaticManagedPagefile -eq $true) {
+            # disable automatic management of the pagefile
+            $pfStatus.AutomaticManagedPagefile = $false
+
+            # we use put() to keep comatibility with PowerShell 2
+            $null = $pfStatus.Put()
+
+            # when we disable the AutomaticManagedPagefile it starts to use the
+            # $env:SystemDrive for the page file so lets remove that
+            Get-WmiObject -Class Win32_PageFileSetting -Filter "SettingID='pagefile.sys @ $($env:SystemDrive)'" -ErrorAction Stop | Remove-WmiObject -ErrorAction Stop
+        }
+
+        # if the pagefile exists on $DriveLetter then remove it
+        Get-WmiObject -Class Win32_PageFileSetting -Filter "SettingID='pagefile.sys @ $($DriveLetter):'" -EnableAllPrivileges -ErrorAction Stop | Remove-WmiObject -ErrorAction Stop
+
+        # create a new instance of a the Wwin32_PageFileSetting object
+        $newPf = (New-Object -TypeName System.Management.ManagementClass('root\cimv2', 'Win32_PageFileSetting', $null)).CreateInstance()
+
+        # we appear to have do do this in bits rather than all at once
+        # See https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-pagefilesetting
+        # set the name first which is simply the path of the pagefile
+        $newPf.Name = "$($DriveLetter):\pagefile.sys"
+        $null = $newPf.Put()
+
+        # now we need to set teh initial and maximum pagefile sizes
+        $newPf.InitialSize = $InitialSizeMB
+        $newPf.MaximumSize = $MaximumSizeMB
+        $null = $newPf.Put()
+    } #function
+
+    # check that maximum is above or equal minimum before we start
+    if ($MaximumSizeMB -lt $InitialSizeMB) {
+        Write-BoxstarterMessage "You have set the maximum pagefile size to be lower than the minimum. Exiting." -color red
+        return
+    }
+
+    ForEach ($dl in $DriveLetter) {
+        # adding DriveType to the WMI Filter doesn't appear to work :(
+        $vol = Get-WmiObject -Class CIM_StorageVolume -Filter "Name='$($dl):\\'" -ErrorAction Stop | Where-Object { $_.DriveType -eq 3 }
+        if ($null -eq $vol) {
+            Write-BoxstarterMessage "Could not find volume '$($dl):'. Either it does not exist or it is not a fixed local volume." -color red
+            return
+        }
+
+        Switch ($PsCmdlet.ParameterSetName) {
+            Disable {
+                try {
+                    Get-WmiObject -Class Win32_PageFileSetting -Filter "Name='$($dl):\\pagefile.sys'" -ErrorAction Stop | Remove-WmiObject -ErrorAction Stop
+                }
+                catch {
+                    Write-BoxStarterMessage "Unable to disable the pagefile on '$($dl):'. (Error: $($_.Exception.Message))"
+                    return
+                }
             }
-            if ($Vol.DriveType -ne 3) {
-                Write-Warning -Message "The selected drive should be a fixed local volume"
-                return
+
+            SystemManagedSize {
+                try {
+                    Set-PageFileSize -DriveLetter $dl -InitialSizeMB 0 -MaximumSizeMB 0
+                }
+                catch {
+                    Write-BoxstarterMessage "Unable to set the pagefile size to be managed by the System. (Error: $($_.Exception.Message))"
+                    return
+                }
+                break
             }
-            Switch ($PsCmdlet.ParameterSetName) {
-                None {
+
+            Default {
+                # $vol stores it's freespace in bytes but we need to compare MB
+                $freespace = $vol.FreeSpace / 1MB
+                if ($freespace -gt $MaximumSizeMB) {
                     try {
-                        $PageFile = Get-WmiObject -Query "Select * From Win32_PageFileSetting Where Name='$($DL):\\pagefile.sys'" -ErrorAction Stop
-                    } catch {
-                        Write-Warning -Message "Failed to query the Win32_PageFileSetting class because $($_.Exception.Message)"
+                        Set-PageFileSize -DriveLetter $dl -InitialSizeMB $InitialSizeMB -MaximumSizeMB $MaximumSizeMB
                     }
-                    If($PageFile) {
-                        try {
-                            $PageFile | Remove-WmiObject -ErrorAction Stop 
-                        } catch {
-                            Write-Warning -Message "Failed to delete pagefile the Win32_PageFileSetting class because $($_.Exception.Message)"
-                        }
-                    } Else {
-                        Write-Warning "$DL is already set None!"
-                    }
-                    break
-                }
-                SystemManagedSize {
-                    Set-PageFileSize -DL $DL -InitialSize 0 -MaximumSize 0
-                    break
-                }
-                Default {
-                    if ($Vol.FreeSpace -gt $MaximumSize) {
-                        Set-PageFileSize -DL $DL -InitialSize $InitialSize -MaximumSize $MaximumSize
-                    } else {
-                        Write-Warning -Message "Maximum size of page file being set exceeds the freespace available on the drive"
+                    catch {
+                        $msg = "Failed to set pagefile on '{0}:' to {1}MB / {2}MB. (Error: $($_.Exception.Message))." -f $dl, $InitialSizeMB, $MaximumSizeMB
+                        Write-BoxstarterMessage $msg -color red
                     }
                 }
-            }
-        }
- 
-        # Get current page file size information
-        try {
-            Get-WmiObject -Class Win32_PageFileSetting -ErrorAction Stop |Select-Object Name,
-        @{Name="InitialSize(MB)";Expression={if($_.InitialSize -eq 0){"System Managed"}else{$_.InitialSize}}}, 
-        @{Name="MaximumSize(MB)";Expression={if($_.MaximumSize -eq 0){"System Managed"}else{$_.MaximumSize}}}| 
+                else {
+                    $msg = "Failed to set pagefile on '{0}:' to {1}MB / {2}MB. The maximum pagefile size exceeds the free space on the volume." -f $dl, $InitialSizeMB, $MaximumSizeMB
+                    Write-BoxstarterMessage $msg -color red
+                    return
+                }
+            } #switch - default
+        } #switch
+    } #foreach
+
+    Write-BoxstarterMessage "A reboot is required before the pagefile changes will take effect."
+    Get-WmiObject -Class Win32_PageFileSetting -ErrorAction Stop |Select-Object Name,
+        @{Name = "InitialSize(MB)"; Expression={ if ($_.InitialSizeMB -eq 0) { "System Managed" } else { $_.InitialSizeMB }}},
+        @{Name = "MaximumSize(MB)"; Expression={ if ($_.MaximumSizeMB -eq 0) { "System Managed" } else { $_.MaximumSizeMB }}} |
         Format-Table -AutoSize
-        } catch {
-            Write-Warning -Message "Failed to query Win32_PageFileSetting class because $($_.Exception.Message)"
-        }
-        If($Reboot) {
-            Restart-Computer -ComputerName $Env:COMPUTERNAME -Force
-        }
-    }
-}
- 
-Function Set-PageFileSize {
-[CmdletBinding()]
-Param(
-        [Parameter(Mandatory)]
-        [Alias('dl')]
-        [ValidatePattern('^[A-Z]$')]
-        [String]$DriveLetter,
- 
-        [Parameter(Mandatory)]
-        [ValidateRange(0,[int32]::MaxValue)]
-        [Int32]$InitialSize,
- 
-        [Parameter(Mandatory)]
-        [ValidateRange(0,[int32]::MaxValue)]
-        [Int32]$MaximumSize
-)
-    #The AutomaticManagedPagefile property determines whether the system managed pagefile is enabled. 
-    #This capability is not available on windows server 2003,XP and lower versions.
-    #Only if it is NOT managed by the system and will also allow you to change these.
-    try {
-        $Sys = Get-WmiObject -Class Win32_ComputerSystem -ErrorAction Stop 
-    } catch {
-         
-    }
- 
-    If($Sys.AutomaticManagedPagefile) {
-        try {
-            $Sys | Set-WmiObject -Property @{ AutomaticManagedPageFile = $false } -ErrorAction Stop
-            Write-Verbose -Message "Set the AutomaticManagedPageFile to false"
-        } catch {
-            Write-Warning -Message "Failed to set the AutomaticManagedPageFile property to false in  Win32_ComputerSystem class because $($_.Exception.Message)"
-        }
-    }
-     
-    # Configuring the page file size
-    try {
-        $PageFile = Get-WmiObject -Class Win32_PageFileSetting -Filter "SettingID='pagefile.sys @ $($DriveLetter):'" -ErrorAction Stop
-    } catch {
-        Write-Warning -Message "Failed to query Win32_PageFileSetting class because $($_.Exception.Message)"
-    }
- 
-    If($PageFile){
-        try {
-            $PageFile | Remove-WmiObject -ErrorAction Stop
-        } catch {
-            Write-Warning -Message "Failed to delete pagefile the Win32_PageFileSetting class because $($_.Exception.Message)"
-        }
-    }
-    try {
-        New-WmiObject -Class Win32_PageFileSetting -Property  @{Name= "$($DriveLetter):\pagefile.sys"} -ErrorAction Stop | Out-Null
-      
-        # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394245%28v=vs.85%29.aspx            
-        Get-WmiObject -Class Win32_PageFileSetting -Filter "SettingID='pagefile.sys @ $($DriveLetter):'" -ErrorAction Stop | Set-CimInstance -Property @{
-            InitialSize = $InitialSize ;
-            MaximumSize = $MaximumSize ; 
-        } -ErrorAction Stop
-         
-        Write-Verbose -Message "Successfully configured the pagefile on drive letter $DriveLetter"
- 
-    } catch {
-        Write-Warning "Pagefile configuration changed on computer '$Env:COMPUTERNAME'. The computer must be restarted for the changes to take effect."
-    }
 }

--- a/Boxstarter.WinConfig/Set-PageFile.ps1
+++ b/Boxstarter.WinConfig/Set-PageFile.ps1
@@ -1,0 +1,236 @@
+#Requires -Version 3.0
+ 
+Function Set-PageFile {
+<#
+    .SYNOPSIS
+        Set-PageFile is an advanced function which can be used to adjust virtual memory page file size.
+    .DESCRIPTION
+        Set-PageFile is an advanced function which can be used to adjust virtual memory page file size.
+    .PARAMETER  <InitialSize>
+        Setting the paging file's initial size.
+    .PARAMETER  <MaximumSize>
+        Setting the paging file's maximum size.
+    .PARAMETER  <DriveLetter>
+        Specifies the drive letter you want to configure.
+    .PARAMETER  <SystemManagedSize>
+        Allow Windows to manage page files on this computer.
+    .PARAMETER  <None>        
+        Disable page files setting.
+    .PARAMETER  <Reboot>      
+        Reboot the computer so that configuration changes take effect.
+    .PARAMETER  <AutoConfigure>
+        Automatically configure the initial size and maximumsize.
+    .EXAMPLE
+        C:\PS> Set-PageFile -InitialSize 1024 -MaximumSize 2048 -DriveLetter "C:","D:"
+ 
+        Execution Results: Set page file size on "C:" successful.
+        Execution Results: Set page file size on "D:" successful.
+ 
+        Name            InitialSize(MB) MaximumSize(MB)
+        ----            --------------- ---------------
+        C:\pagefile.sys            1024            2048
+        D:\pagefile.sys            1024            2048
+        E:\pagefile.sys            2048            2048
+    .LINK
+        Get-WmiObject
+        http://technet.microsoft.com/library/hh849824.aspx
+#>
+    [cmdletbinding(SupportsShouldProcess,DefaultParameterSetName="SetPageFileSize")]
+    Param
+    (
+        [Parameter(Mandatory,ParameterSetName="SetPageFileSize")]
+        [Alias('is')]
+        [Int32]$InitialSize,
+ 
+        [Parameter(Mandatory,ParameterSetName="SetPageFileSize")]
+        [Alias('ms')]
+        [Int32]$MaximumSize,
+ 
+        [Parameter(Mandatory)]
+        [Alias('dl')]
+        [ValidatePattern('^[A-Z]$')]
+        [String[]]$DriveLetter,
+ 
+        [Parameter(Mandatory,ParameterSetName="None")]
+        [Switch]$None,
+ 
+        [Parameter(Mandatory,ParameterSetName="SystemManagedSize")]
+        [Switch]$SystemManagedSize,
+ 
+        [Parameter()]
+        [Switch]$Reboot,
+ 
+        [Parameter(Mandatory,ParameterSetName="AutoConfigure")]
+        [Alias('auto')]
+        [Switch]$AutoConfigure
+    )
+Begin {}
+Process {
+    If($PSCmdlet.ShouldProcess("Setting the virtual memory page file size")) {
+        $DriveLetter | ForEach-Object -Process {
+            $DL = $_
+            $PageFile = $Vol = $null
+            try {
+                $Vol = Get-CimInstance -ClassName CIM_StorageVolume -Filter "Name='$($DL):\\'" -ErrorAction Stop
+            } catch {
+                Write-Warning -Message "Failed to find the DriveLetter $DL specified"
+                return
+            }
+            if ($Vol.DriveType -ne 3) {
+                Write-Warning -Message "The selected drive should be a fixed local volume"
+                return
+            }
+            Switch ($PsCmdlet.ParameterSetName) {
+                None {
+                    try {
+                        $PageFile = Get-CimInstance -Query "Select * From Win32_PageFileSetting Where Name='$($DL):\\pagefile.sys'" -ErrorAction Stop
+                    } catch {
+                        Write-Warning -Message "Failed to query the Win32_PageFileSetting class because $($_.Exception.Message)"
+                    }
+                    If($PageFile) {
+                        try {
+                            $PageFile | Remove-CimInstance -ErrorAction Stop 
+                        } catch {
+                            Write-Warning -Message "Failed to delete pagefile the Win32_PageFileSetting class because $($_.Exception.Message)"
+                        }
+                    } Else {
+                        Write-Warning "$DL is already set None!"
+                    }
+                    break
+                }
+                SystemManagedSize {
+                    Set-PageFileSize -DL $DL -InitialSize 0 -MaximumSize 0
+                    break
+                }
+                AutoConfigure {         
+                    $TotalPhysicalMemorySize = @()
+                    #Getting total physical memory size
+                    try {
+                        Get-CimInstance Win32_PhysicalMemory  -ErrorAction Stop | ? DeviceLocator -ne "SYSTEM ROM" | ForEach-Object {
+                            $TotalPhysicalMemorySize += [Double]($_.Capacity)/1GB
+                        }
+                    } catch {
+                        Write-Warning -Message "Failed to query the Win32_PhysicalMemory class because $($_.Exception.Message)"
+                    }       
+                    <#
+                    By default, the minimum size on a 32-bit (x86) system is 1.5 times the amount of physical RAM if physical RAM is less than 1 GB, 
+                    and equal to the amount of physical RAM plus 300 MB if 1 GB or more is installed. The default maximum size is three times the amount of RAM, 
+                    regardless of how much physical RAM is installed. 
+                    If($TotalPhysicalMemorySize -lt 1) {
+                        $InitialSize = 1.5*1024
+                        $MaximumSize = 1024*3
+                        Set-PageFileSize -DL $DL -InitialSize $InitialSize -MaximumSize $MaximumSize
+                    } Else {
+                        $InitialSize = 1024+300
+                        $MaximumSize = 1024*3
+                        Set-PageFileSize -DL $DL -InitialSize $InitialSize -MaximumSize $MaximumSize
+                    }
+                    #>
+ 
+ 
+                    $InitialSize = (Get-CimInstance -ClassName Win32_PageFileUsage).AllocatedBaseSize
+                    $sum = $null
+                    (Get-Counter '\Process(*)\Page File Bytes Peak' -SampleInterval 15 -ErrorAction SilentlyContinue).CounterSamples.CookedValue | % {$sum += $_}
+                    $MaximumSize = ($sum*70/100)/1MB
+                    if ($Vol.FreeSpace -gt $MaximumSize) {
+                        Set-PageFileSize -DL $DL -InitialSize $InitialSize -MaximumSize $MaximumSize
+                    } else {
+                        Write-Warning -Message "Maximum size of page file being set exceeds the freespace available on the drive"
+                    }
+                    break
+                                 
+                }
+                Default {
+                    if ($Vol.FreeSpace -gt $MaximumSize) {
+                        Set-PageFileSize -DL $DL -InitialSize $InitialSize -MaximumSize $MaximumSize
+                    } else {
+                        Write-Warning -Message "Maximum size of page file being set exceeds the freespace available on the drive"
+                    }
+                }
+            }
+        }
+ 
+        # Get current page file size information
+        try {
+            Get-CimInstance -ClassName Win32_PageFileSetting -ErrorAction Stop |Select-Object Name,
+        @{Name="InitialSize(MB)";Expression={if($_.InitialSize -eq 0){"System Managed"}else{$_.InitialSize}}}, 
+        @{Name="MaximumSize(MB)";Expression={if($_.MaximumSize -eq 0){"System Managed"}else{$_.MaximumSize}}}| 
+        Format-Table -AutoSize
+        } catch {
+            Write-Warning -Message "Failed to query Win32_PageFileSetting class because $($_.Exception.Message)"
+        }
+        If($Reboot) {
+            Restart-Computer -ComputerName $Env:COMPUTERNAME -Force
+        }
+    }
+}
+End {}
+}
+ 
+Function Set-PageFileSize {
+[CmdletBinding()]
+Param(
+        [Parameter(Mandatory)]
+        [Alias('dl')]
+        [ValidatePattern('^[A-Z]$')]
+        [String]$DriveLetter,
+ 
+        [Parameter(Mandatory)]
+        [ValidateRange(0,[int32]::MaxValue)]
+        [Int32]$InitialSize,
+ 
+        [Parameter(Mandatory)]
+        [ValidateRange(0,[int32]::MaxValue)]
+        [Int32]$MaximumSize
+)
+Begin {}
+Process {
+    #The AutomaticManagedPagefile property determines whether the system managed pagefile is enabled. 
+    #This capability is not available on windows server 2003,XP and lower versions.
+    #Only if it is NOT managed by the system and will also allow you to change these.
+    try {
+        $Sys = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop 
+    } catch {
+         
+    }
+ 
+    If($Sys.AutomaticManagedPagefile) {
+        try {
+            $Sys | Set-CimInstance -Property @{ AutomaticManagedPageFile = $false } -ErrorAction Stop
+            Write-Verbose -Message "Set the AutomaticManagedPageFile to false"
+        } catch {
+            Write-Warning -Message "Failed to set the AutomaticManagedPageFile property to false in  Win32_ComputerSystem class because $($_.Exception.Message)"
+        }
+    }
+     
+    # Configuring the page file size
+    try {
+        $PageFile = Get-CimInstance -ClassName Win32_PageFileSetting -Filter "SettingID='pagefile.sys @ $($DriveLetter):'" -ErrorAction Stop
+    } catch {
+        Write-Warning -Message "Failed to query Win32_PageFileSetting class because $($_.Exception.Message)"
+    }
+ 
+    If($PageFile){
+        try {
+            $PageFile | Remove-CimInstance -ErrorAction Stop
+        } catch {
+            Write-Warning -Message "Failed to delete pagefile the Win32_PageFileSetting class because $($_.Exception.Message)"
+        }
+    }
+    try {
+        New-CimInstance -ClassName Win32_PageFileSetting -Property  @{Name= "$($DriveLetter):\pagefile.sys"} -ErrorAction Stop | Out-Null
+      
+        # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394245%28v=vs.85%29.aspx            
+        Get-CimInstance -ClassName Win32_PageFileSetting -Filter "SettingID='pagefile.sys @ $($DriveLetter):'" -ErrorAction Stop | Set-CimInstance -Property @{
+            InitialSize = $InitialSize ;
+            MaximumSize = $MaximumSize ; 
+        } -ErrorAction Stop
+         
+        Write-Verbose -Message "Successfully configured the pagefile on drive letter $DriveLetter"
+ 
+    } catch {
+        Write-Warning "Pagefile configuration changed on computer '$Env:COMPUTERNAME'. The computer must be restarted for the changes to take effect."
+    }
+}
+End {}
+}

--- a/Boxstarter.WinConfig/Set-PageFile.ps1
+++ b/Boxstarter.WinConfig/Set-PageFile.ps1
@@ -1,3 +1,4 @@
+#Andrea Dalle Vacche
 #Requires -Version 3.0
  
 Function Set-PageFile {
@@ -21,16 +22,16 @@ Function Set-PageFile {
     .PARAMETER  <AutoConfigure>
         Automatically configure the initial size and maximumsize.
     .EXAMPLE
-        C:\PS> Set-PageFile -InitialSize 1024 -MaximumSize 2048 -DriveLetter "C:","D:"
+        C:\PS> Set-PageFile -InitialSize 1024 -MaximumSize 4096 -DriveLetter "C","D"
  
-        Execution Results: Set page file size on "C:" successful.
+        Execution Results: Set page file size on "C" successful.
         Execution Results: Set page file size on "D:" successful.
  
         Name            InitialSize(MB) MaximumSize(MB)
         ----            --------------- ---------------
-        C:\pagefile.sys            1024            2048
-        D:\pagefile.sys            1024            2048
-        E:\pagefile.sys            2048            2048
+        C:\pagefile.sys            1024            4096
+        D:\pagefile.sys            1024            4096
+        E:\pagefile.sys            2048            4096
     .LINK
         Get-WmiObject
         http://technet.microsoft.com/library/hh849824.aspx


### PR DESCRIPTION
This is only a new function: Set-PageFile that enable BoxStarter to set the swapfile on the box where is getting executed.
Set-PageFile is an advanced function which can be used to adjust virtual memory page file size.

    .PARAMETER  <InitialSize>
        Setting the paging file's initial size.
    .PARAMETER  <MaximumSize>
        Setting the paging file's maximum size.
    .PARAMETER  <DriveLetter>
        Specifies the drive letter you want to configure.
    .PARAMETER  <SystemManagedSize>
        Allow Windows to manage page files on this computer.
    .PARAMETER  <None>        
        Disable page files setting.
    .PARAMETER  <Reboot>      
        Reboot the computer so that configuration changes take effect.
    .PARAMETER  <AutoConfigure>
        Automatically configure the initial size and maximumsize.
    .EXAMPLE
        C:\PS> Set-PageFile -InitialSize 1024 -MaximumSize 4096 -DriveLetter "C","D"

