### PR TITLE
(GH-227) Fix build

### DIFF
--- a/Boxstarter.ClickOnce/Boxstarter.WebLaunch.csproj
+++ b/Boxstarter.ClickOnce/Boxstarter.WebLaunch.csproj
@@ -148,4 +148,8 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <PropertyGroup>
+    <!-- This is set to true by default if targetting .NET 2.0, 3.0 OR SignManifest == true. Override that for non-official builds. -->
+    <_DeploymentSignClickOnceManifests Condition="'$(CHOCOLATEY_OFFICIAL_CERT)' == ''">false</_DeploymentSignClickOnceManifests>
+  </PropertyGroup>
 </Project>

--- a/BuildScripts/build.ps1
+++ b/BuildScripts/build.ps1
@@ -10,13 +10,13 @@ if(-not $env:ChocolateyInstall -or -not (Test-Path "$env:ChocolateyInstall")){
     iex ((new-object net.webclient).DownloadString("https://bit.ly/psChocInstall"))
 }
 
-if(!(Test-Path $env:ChocolateyInstall\lib\Psake*)) { cinst psake -y }
-if(!(Test-Path $env:ChocolateyInstall\lib\7zip.CommandLine*)) { cinst 7zip.CommandLine -y }
-if(!(Test-Path $env:ChocolateyInstall\lib\pester*)) { cinst pester -v 3.4.0 -y }
-if(!(Test-Path $env:ChocolateyInstall\lib\AzurePowershell*)) { cinst AzurePowershell -y }
-if(!(Test-Path $env:ChocolateyInstall\lib\WindowsAzureLibsForNet*)) { cinst WindowsAzureLibsForNet --version 2.5 -y }
-if(!(Test-Path $env:ChocolateyInstall\bin\nuget.exe)) { cinst nuget.commandline -y }
-if(!(Test-Path $env:ChocolateyInstall\bin\ReportUnit.exe)) { choco install reportunit -y --source https://nuget.org/api/v2 }
+if(!(Test-Path $env:ChocolateyInstall\lib\Psake*)) { cinst psake -y --no-progress }
+if(!(Test-Path $env:ChocolateyInstall\lib\7zip.CommandLine*)) { cinst 7zip.CommandLine -y --no-progress }
+if(!(Test-Path $env:ChocolateyInstall\lib\pester*)) { cinst pester -v 3.4.0 -y --no-progress }
+if(!(Test-Path $env:ChocolateyInstall\lib\AzurePowershell*)) { cinst AzurePowershell -y --no-progress }
+if(!(Test-Path $env:ChocolateyInstall\lib\WindowsAzureLibsForNet*)) { cinst WindowsAzureLibsForNet --version 2.5 -y --no-progress }
+if(!(Test-Path $env:ChocolateyInstall\bin\nuget.exe)) { cinst nuget.commandline -y --no-progress }
+if(!(Test-Path $env:ChocolateyInstall\bin\ReportUnit.exe)) { choco install reportunit -y --source https://nuget.org/api/v2 --no-progress }
 
 if($Help){
   try {

--- a/BuildScripts/build.ps1
+++ b/BuildScripts/build.ps1
@@ -12,7 +12,7 @@ if(-not $env:ChocolateyInstall -or -not (Test-Path "$env:ChocolateyInstall")){
 
 if(!(Test-Path $env:ChocolateyInstall\lib\Psake*)) { cinst psake -y --no-progress }
 if(!(Test-Path $env:ChocolateyInstall\lib\7zip.CommandLine*)) { cinst 7zip.CommandLine -y --no-progress }
-if(!(Test-Path $env:ChocolateyInstall\lib\pester*)) { cinst pester -v 3.4.0 -y --no-progress }
+if(!(Test-Path $env:ChocolateyInstall\lib\pester*)) { cinst pester -y --no-progress }
 if(!(Test-Path $env:ChocolateyInstall\lib\AzurePowershell*)) { cinst AzurePowershell -y --no-progress }
 if(!(Test-Path $env:ChocolateyInstall\lib\WindowsAzureLibsForNet*)) { cinst WindowsAzureLibsForNet --version 2.5 -y --no-progress }
 if(!(Test-Path $env:ChocolateyInstall\bin\nuget.exe)) { cinst nuget.commandline -y --no-progress }

--- a/BuildScripts/default.ps1
+++ b/BuildScripts/default.ps1
@@ -231,7 +231,7 @@ mget *
 bye
 "@
     $ftpScript | ftp -i -n $ftpHost
-    if(!(Test-Path $env:ChocolateyInstall\lib\logparser*)) { cinst logparser -y }
+    if(!(Test-Path $env:ChocolateyInstall\lib\logparser*)) { cinst logparser -y --no-progress }
     $logParser = "${env:programFiles(x86)}\Log Parser 2.2\LogParser.exe"
     .$logparser -i:w3c "SELECT Date, EXTRACT_VALUE(cs-uri-query,'package') as package, COUNT(*) as count FROM * where cs-uri-stem = '/launch/Boxstarter.WebLaunch.Application' Group by Date, package Order by Date, package" -rtp:-1
     popd
@@ -239,15 +239,15 @@ bye
 }
 
 task Install-MSBuild {
-    if(!(Test-Path "$env:ProgramFiles\MSBuild\14.0\Bin\msbuild.exe")) { cinst microsoft-build-tools --version 14.0.23107.10 -y }
+    if(!(Test-Path "$env:ProgramFiles\MSBuild\14.0\Bin\msbuild.exe")) { cinst microsoft-build-tools --version 14.0.23107.10 -y --no-progress }
 }
 
 task Install-Win8SDK {
-    if(!(Test-Path "$env:ProgramFiles\Windows Kits\8.1\bin\x64\signtool.exe")) { cinst windows-sdk-8.1 -y }
+    if(!(Test-Path "$env:ProgramFiles\Windows Kits\8.1\bin\x64\signtool.exe")) { cinst windows-sdk-8.1 -y --no-progress }
 }
 
 task Install-WebDeploy {
-    if(!(Test-Path "$env:ProgramW6432\IIS\Microsoft Web Deploy V3")) { cinst webdeploy -y }
+    if(!(Test-Path "$env:ProgramW6432\IIS\Microsoft Web Deploy V3")) { cinst webdeploy -y --no-progress }
 }
 
 Task Restore-NuGetPackages {


### PR DESCRIPTION
Resolves #227 - allows CI build to pass by disabling ClickOnce signing if no certificate is present

Also tidy up appveyor build by suppressing Chocolatey progress output.