### PR TITLE
(GH-331) BoxstarterConnectionConfig Params

### DIFF
--- a/Boxstarter.Chocolatey/Install-BoxstarterPackage.ps1
+++ b/Boxstarter.Chocolatey/Install-BoxstarterPackage.ps1
@@ -59,9 +59,9 @@ This function wraps a Chocolatey Install and provides these additional features
 
  .PARAMETER BoxstarterConnectionConfig
  If provided, Boxstarter will install the specified package name on all computers
- included in the BoxstarterConnectionConfig. This object contains a ComputerName
- and a PSCredential. Use this object if you need to pass different computers
- requiring different credentials.
+ included in the BoxstarterConnectionConfig. This object contains a ConnectionURI
+ a PSCredential, and an optional PSSessionOption. Use this object if you need to
+ pass different computers requiring different credentials.
 
  .PARAMETER PackageName
  The names of one or more NuGet Packages to be installed or URIs or
@@ -224,8 +224,8 @@ proceeding to the other computers.
 .EXAMPLE
 $cred1=Get-Credential mwrock
 $cred2=Get-Credential domain\mwrock
-(New-Object -TypeName BoxstarterConnectionConfig -ArgumentList "computer1",$cred1), `
-(New-Object -TypeName BoxstarterConnectionConfig -ArgumentList "computer2",$cred2) |
+(New-Object -TypeName BoxstarterConnectionConfig -ArgumentList "http://computer1:5985/wsman",$cred1,$null), `
+(New-Object -TypeName BoxstarterConnectionConfig -ArgumentList "http://computer2:5985/wsman",$cred2,$null) |
 Install-BoxstarterPackage -Package MyPackage
 
 This installs the MyPackage package on computer1 and computer2 and uses

--- a/Web/InstallingPackages.cshtml
+++ b/Web/InstallingPackages.cshtml
@@ -139,12 +139,12 @@ StartTime    : 11/30/2013 1:56:36 AM
 </pre>
 
 <h3>Using BoxstarterConnectionConfig objects</h3>
-<p>If you have multiple machines you want to install but they require different credentials, use a BoxstarterConnectionConfig. This class contains a ComputerName and a PSCredential property that you can set and pipe to <code>Install-BoxstarterPackage</code>.</p>
+<p>If you have multiple machines you want to install but they require different credentials, use a BoxstarterConnectionConfig. This class contains a ConnectionURI, a PSCredential and an optional <a href="https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/new-pssessionoption">PSSessionOption</a> property that you can set and pipe to <code>Install-BoxstarterPackage</code>.</p>
 <pre>
 $cred1=Get-Credential 'MyTargetMachine\myusername'
 $cred2=Get-Credential 'Domain\myDomainUser'
-$result = (new-Object -TypeName BoxstarterConnectionConfig -ArgumentList machine1,$cred1),`
-    (new-Object -TypeName BoxstarterConnectionConfig -ArgumentList machine2,$cred2) |
+$result = (new-Object -TypeName BoxstarterConnectionConfig -ArgumentList 'http://machine1:5985/wsman',$cred1,$null),`
+    (new-Object -TypeName BoxstarterConnectionConfig -ArgumentList 'http://machine2:5985/wsman',$cred2,$null) |
     Install-BoxstarterPackage -PackageName MyPackage
 </pre>
 <h3>Troubleshooting Remote Installations</h3>


### PR DESCRIPTION
This updates the documentation for "Using BoxstarterConnectionConfig objects" to align with the code. The original example code did not work.

Fixes #331 