### PR TITLE
(GH-336) Fix uninstall leftover shortcut

### DIFF
--- a/BuildScripts/chocolateyUninstall.ps1
+++ b/BuildScripts/chocolateyUninstall.ps1
@@ -1,0 +1,11 @@
+$tools = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+. (Join-Path -Path $tools -ChildPath 'Setup.ps1')
+
+try {
+    $ModuleName = (Get-ChildItem $tools | Where-Object { $_.PSIsContainer }).BaseName
+    Uninstall-Boxstarter $tools $ModuleName $env:chocolateyPackageParameters
+}
+catch {
+    Write-Output $_ | Format-List * -force
+    throw $_.Exception
+}

--- a/BuildScripts/default.ps1
+++ b/BuildScripts/default.ps1
@@ -272,6 +272,7 @@ task Copy-PowerShellFiles -depends Clean-Artifacts {
     $exclude = @("bin", "obj", "*.pssproj")
 
     Copy-Item -Path $basedir\BuildScripts\chocolateyinstall.ps1 -Destination $tempNuGetDirectory
+    Copy-Item -Path $basedir\BuildScripts\chocolateyUninstall.ps1 -Destination $tempNuGetDirectory    
     Copy-Item -Path $basedir\BuildScripts\setup.ps1 -Destination $tempNuGetDirectory
     Copy-Item -Path $basedir\BuildScripts\nuget\Boxstarter.Azure.PreInstall.ps1 -Destination $tempNuGetDirectory
     Copy-Item -Path $basedir\BuildScripts\BoxstarterChocolateyInstall.ps1 -Destination $tempNuGetDirectory

--- a/BuildScripts/nuget/Boxstarter.Chocolatey.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Chocolatey.nuspec
@@ -29,6 +29,7 @@
   </metadata>
   <files>
     <file src="..\..\buildArtifacts\tempNuGetFolders\chocolateyinstall.ps1" target="tools" />
+    <file src="..\..\buildArtifacts\tempNuGetFolders\chocolateyUninstall.ps1" target="tools" />
     <file src="..\..\buildArtifacts\tempNuGetFolders\Setup.ps1" target="tools" />
     <file src="..\..\boxstarter.bat" target="tools" />
     <file src="..\..\boxstarter.config" target="tools" />

--- a/BuildScripts/setup.ps1
+++ b/BuildScripts/setup.ps1
@@ -71,6 +71,12 @@ function Uninstall-Boxstarter ($here, $ModuleName, $installArgs = "") {
             Write-Verbose "Removing '$startMenu' menu folder"
             Remove-Item -Path $startMenu -Recurse -Force
         }
+
+        $desktopShortcut = Join-Path -Path ([Environment]::GetFolderPath('CommonDesktop')) -ChildPath "Boxstarter Shell.lnk"
+        if (Test-Path $desktopShortcut) {
+            Write-Verbose "Removing '$desktopShortcut'"
+            Remove-Item -Path $desktopShortcut -Force
+        }
     }
 }
 

--- a/BuildScripts/setup.ps1
+++ b/BuildScripts/setup.ps1
@@ -62,6 +62,18 @@ PS:>Get-Help Boxstarter
     }
 }
 
+function Uninstall-Boxstarter ($here, $ModuleName, $installArgs = "") {
+
+    if ($ModuleName -eq "Boxstarter.Chocolatey" -and !$env:appdata.StartsWith($env:windir)) {
+        $startMenu = Join-Path -Path ([Environment]::GetFolderPath('CommonPrograms')) -ChildPath "Boxstarter"
+
+        if (Test-Path $startMenu) {
+            Write-Verbose "Removing '$startMenu' menu folder"
+            Remove-Item -Path $startMenu -Recurse -Force
+        }
+    }
+}
+
 function Create-Shortcut($location, $target, $targetArgs, $boxstarterPath) {
     $wshshell = New-Object -ComObject WScript.Shell
     $lnk = $wshshell.CreateShortcut($location)


### PR DESCRIPTION
Remove the start menu shortcut that is created by the Boxstarter.Chocolatey package.