### PR TITLE
(GH-347) Add .editorconfig to define project standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+
+root = true
+
+[*]
+end_of_line = crlf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{ps1,psm1,psd1}]
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,8 @@ root = true
 
 [*]
 end_of_line = crlf
-insert_final_newline = true
-trim_trailing_whitespace = true
+insert_final_newline = false
+trim_trailing_whitespace = false
 
 [*.{ps1,psm1,psd1}]
 charset = utf-8

--- a/Boxstarter.sln
+++ b/Boxstarter.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BuildScripts", "BuildScript
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9934F8F4-B4E6-4C70-8BEA-30CCF926284A}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		BoxStarter.bat = BoxStarter.bat
 		boxstarter.config = boxstarter.config

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ Start with [Prerequisites](#prerequisites).
  * The last parameter in every function must be `[parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments`. This allows for future expansion and compatibility - as new parameters are introduced and used, it doesn't break older versions of Boxstarter.
  * Do not add new positional elements to functions. We want to promote using named parameters in calling functions.
  * Do not remove any existing positional elements from functions. We need to maintain compatibility with older versions of Boxstarter.
- * There is a `.editorconfig` file that ensures basic settings such as file encoding, tab width and line endings. In Visual Studio 2017 it should be used by default, in prior versions you need to install the "editorconfig plugin".
+ * There is a `.editorconfig` file that ensures basic settings such as file encoding, tab width and line endings. In Visual Studio 2017 it should be used by default, in prior versions you need to install the "[editorconfig plugin](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)".
  * When using vscode, be sure to install the PowerShell and editorconfig plugins:
    * `code --install-extension ms-vscode.powershell`
    * `code --install-extension editorconfig.editorconfig`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,10 @@ Start with [Prerequisites](#prerequisites).
  * The last parameter in every function must be `[parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments`. This allows for future expansion and compatibility - as new parameters are introduced and used, it doesn't break older versions of Boxstarter.
  * Do not add new positional elements to functions. We want to promote using named parameters in calling functions.
  * Do not remove any existing positional elements from functions. We need to maintain compatibility with older versions of Boxstarter.
+ * There is a `.editorconfig` file that ensures basic settings such as file encoding, tab width and line endings. In Visual Studio 2017 it should be used by default, in prior versions you need to install the "editorconfig plugin".
+ * When using vscode, be sure to install the PowerShell and editorconfig plugins:
+   * `code --install-extension ms-vscode.powershell`
+   * `code --install-extension editorconfig.editorconfig`
 
 ### Prepare Commits
 This section serves to help you understand what makes a good commit.


### PR DESCRIPTION
Added basic .editorconfig file with the following settings:

for all
* end of line: CRLF
* insert final newline
* trim trailingi whitespace

for *.ps1 / *.psm1 / *.psd1
* charset: utf-8
* ident: spaces
* ident width: 4

also included a quick note in CONTRIBUTING.md how to install the required plugins in vscode.