### PR TITLE
bumped bootstrap 3.0.2 to 3.4.1

### DIFF
--- a/Web/packages.config
+++ b/Web/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="bootstrap" version="3.0.2" targetFramework="net45" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net45" />
   <package id="jQuery" version="1.9.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.0.0" targetFramework="net45" />


### PR DESCRIPTION
bumped bootstrap (web toolkit) from version 3.0.2 to 3.4.1

for notes on what changed see https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/

I've tested the website (Project "Web" in Boxstarter.sln) locally with IIS Express - everyting seems to be working as expected.