### PR TITLE
(GH-389) fix RebootCodes option for cinst wrapper

### DIFF
--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -152,7 +152,7 @@ Intercepts Chocolatey call to check for reboots
         catch {
             #Only write the error to the error stream if it was not previously
             #written by Chocolatey
-            $chocoErrors = $global:error.Count - $currentErrorCount
+            $chocoErrors = $currentErrorCount
             if($chocoErrors -gt 0){
                 $idx = 0
                 $errorWritten = $false

--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -103,7 +103,7 @@ Intercepts Chocolatey call to check for reboots
                 $skipNextArg = $false;
                 continue;
             }
-            if ($a -eq "-RebootCodes" -or $a -eq "--RebootCodes") {
+            if (@("-RebootCodes", "--RebootCodes") -contains $a) {
                 $skipNextArg = $true
                 continue;
             }
@@ -128,7 +128,7 @@ Intercepts Chocolatey call to check for reboots
         }
         if(((Test-PendingReboot) -or $Boxstarter.IsRebooting) -and $Boxstarter.RebootOk) {return Invoke-Reboot}
         $session=Start-TimedSection "Calling Chocolatey to install $packageName. This may take several minutes to complete..."
-        $currentErrorCount = $global:error.Count
+        $currentErrorCount = 0
         $rebootable = $false
         try {
             [System.Environment]::ExitCode = 0
@@ -167,7 +167,7 @@ Intercepts Chocolatey call to check for reboots
                 }
             }
         }
-        $chocoErrors = $global:error.Count - $currentErrorCount
+        $chocoErrors = $currentErrorCount
         if($chocoErrors -gt 0){
             Write-BoxstarterMessage "There was an error calling Chocolatey" -Verbose
             $idx = 0

--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -95,7 +95,7 @@ Intercepts Chocolatey call to check for reboots
         [string[]]$packageNames=@('')
     )
     $RebootCodes = Get-PassedArg RebootCodes $args
-    if ($RebootCodes) {
+    if ($null -ne $RebootCodes) {
         $argsWithoutRebootCodes = @()
         $skipNextArg = $false
         foreach ($a in $args) {
@@ -111,23 +111,23 @@ Intercepts Chocolatey call to check for reboots
         }
         $args = $argsWithoutRebootCodes
     }
-    $RebootCodes=Add-DefaultRebootCodes $RebootCodes
+    $RebootCodes = Add-DefaultRebootCodes $RebootCodes
     Write-BoxstarterMessage "RebootCodes: '$RebootCodes'" -Verbose
 
-    $packageNames=-split $packageNames
+    $packageNames = -split $packageNames
     Write-BoxstarterMessage "Installing $($packageNames.Count) packages" -Verbose
 
     foreach($packageName in $packageNames){
         $PSBoundParameters.packageNames = $packageName
         if((Get-PassedArg @("source", "s") $args) -eq "WindowsFeatures"){
-            $dismInfo=(DISM /Online /Get-FeatureInfo /FeatureName:$packageName)
+            $dismInfo = (DISM /Online /Get-FeatureInfo /FeatureName:$packageName)
             if($dismInfo -contains "State : Enabled" -or $dismInfo -contains "State : Enable Pending") {
                 Write-BoxstarterMessage "$packageName is already installed"
                 return
             }
         }
         if(((Test-PendingReboot) -or $Boxstarter.IsRebooting) -and $Boxstarter.RebootOk) {return Invoke-Reboot}
-        $session=Start-TimedSection "Calling Chocolatey to install $packageName. This may take several minutes to complete..."
+        $session = Start-TimedSection "Calling Chocolatey to install $packageName. This may take several minutes to complete..."
         $currentErrorCount = 0
         $rebootable = $false
         try {

--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -180,7 +180,7 @@ Intercepts Chocolatey call to check for reboots
                         $errorCode=$matches["ecof"]
                     }
                     if($RebootCodes -contains $errorCode) {
-                       Write-BoxstarterMessage "Chocolatey Install returned a rebootable exit code" -Verbose
+                       Write-BoxstarterMessage "Chocolatey install returned a rebootable exit code ($errorCode)" -Verbose
                        $rebootable = $true
                     } else {
                        Write-BoxstarterMessage "Exit Code '$errorCode' is no reason to reboot" -Verbose 


### PR DESCRIPTION
This should "re-enable" the possibility to pass `-RebootCodes` to Chocolatey commands in Boxstarter packages.

I stumbled across the parameter in the tests (i.e. [here](https://github.com/chocolatey/boxstarter/blob/9596ea327d597419e80e9535e01aa2923ac60619/tests/Chocolatey/Chocolatey.tests.ps1#L96)) and wanted to use this feature in my generic Boxstarter bootstrapper files, however there are several small bugs/inconsistencies that basically render this unusable in the current state.

inside a Boxstarter package:

## samplePackage.ps1
```
cinst far 
cinst foobar -RebootCodes @(8, 3010, 42)
cinst barz
```

when installing `samplePackage.ps1` via Boxstarter wrapper (`BoxStarter.bat`), `Invoke-Reboot` will be triggered immediately after a package (far, foobar or barz) returned a "valid reboot code".
