### PR TITLE
(GH-120)(GH-390) Resolve boxstarter.org navigation and depreciated Bootstrap classes

### DIFF
--- a/Web/CreatingPackages.cshtml
+++ b/Web/CreatingPackages.cshtml
@@ -53,7 +53,7 @@ try {
 <p>
     These files are saved to your local Boxstarter Repository. This is where Boxstarter will store your local packages and running the Install-BoxstarterPackage command will look here first before any external feed. The repository is located in your AppData directory but you can always find out exactly where by inspecting the global Boxstarter variable <code>$Boxstarter.LocalRepo</code>.
 </p>
-<img src="Images/global.png"/>
+<img class="img-responsive" src="Images/global.png"/>
 <p>You can change the location by using the Set-BoxstarterConfig command:</p>
 <pre>
 Set-BoxstarterConfig -LocalRepo "c:\some\other\location"

--- a/Web/InstallBoxstarter.cshtml
+++ b/Web/InstallBoxstarter.cshtml
@@ -19,11 +19,11 @@
 <pre>
 CINST Boxstarter
 </pre>
-<img src="images\installed.png" />
+<img class="img-responsive" src="images\installed.png" />
 <p>This will download and install the Boxstarter modules to your PSModulePath.</p>
 <h3>Downloading the zip file</h3>
 <p>The zip file contains a Setup.Bat file that will go to Chocolatey and install Boxstarter. If Chocolatey is not installed on your machine, the Boxstarter installer will request the user's permission to install it. Note: Setup.bat accepts a <code>-Force</code> argument to suppress this prompt.</p>
-<img src="Images/setup.png"/>
+<img class="img-responsive" src="Images/setup.png"/>
 <p>Boxstarter is now installed in your modules path!</p>
 
 <p>Both the Chocolatey Boxstarter package and the downloaded zip file available on this website install all Boxstarter modules except the Boxstarter.Azure module which provides integration with Windows Azure VMs. You can install the Azure module by running <code>CINST Boxstarter.Azure</code>. In addition to the Boxstarter.Azure module, it also installs the Windows Azure PowerShell toolkit, the Azure SDK for .Net Libraries and .Net 4.5. It requires PowerShell 3 or higher (the version installed with Windows 8/server 2012 and higher but also <a href="https://www.microsoft.com/en-us/download/details.aspx?id=40855">freely available for download</a> on older versions) to install successfully.</p>

--- a/Web/InstallingPackages.cshtml
+++ b/Web/InstallingPackages.cshtml
@@ -89,7 +89,7 @@ E:\BoxstarterDir\Boxstarter example
     <li>Invoke a Boxstarter installation of the example package</li>
     <li>Will prompt the user for their password to use during reboots</li>
 </ul>
-<img src="Images/console.png"/>
+<img class="img-responsive" src="Images/console.png"/>
 
 <h3>Creating a Boxstarter Share</h3>
 <p>As stated already, Boxstarter and its local repository can exist on a network share. Boxstarter provides a command that will share the directory where Boxstarter exists.</p>
@@ -118,7 +118,7 @@ Install-BoxstarterPackage -ComputerName MyTargetMachine -PackageName MyPackage -
 </pre>
 <p>Boxstarter will use the credential to connect to MyTargetMachine and will copy the Boxstarter modules and your Local Repository packages to its local storage. It will then run the package on that machine. Boxstarter will configure your local machine to be able to connect to the remote machine and it may prompt you for permission to change settings. You can always provide the -Force parameter to silence the prompts and allow boxstarter to freely enable remoting if it is not already enabled.</p>
 <p>Here is a screen shot of Boxstarter installing a Minecraft Server (bukkit) on a AWS EC2 instance:</p>
-<img src="Images/amazon.png"/>
+<img class="img-responsive" src="Images/amazon.png"/>
 <p>You can pipe several computer names, URIs or Windows PowerShell sessions to <code>Install-BoxstarterPackage</code>. Boxstarter will attempt to install the package on each machine and return a PSObject result for each machine.</p>
 <pre>
 $cred=Get-Credential 'MyTargetMachine\myusername'

--- a/Web/Learn/RemotePackageWithArtifacts.cshtml
+++ b/Web/Learn/RemotePackageWithArtifacts.cshtml
@@ -12,7 +12,7 @@
 <h3>Step 1</h3>
 <h4><span class="text-primary">Create and Build the NuGet server</span></h4>
 <p>Create an empty Web Application in Visual Studio and add a NuGet reference to NuGet.Server. After the package install completes, build the solution. NOTE: This can be performed with the free Visual Studio Express for Web which can be installed via Chocolatey - <code>cinst VisualStudio2013ExpressWeb</code>.</p>
-<img src="~/Images/NugetServer.png">
+<img class="img-responsive" src="~/Images/NugetServer.png">
 
 <h3>Step 2</h3>
 <h4><span class="text-primary">Install Boxstarter</span></h4>
@@ -22,7 +22,7 @@
 
 <h3>Step 3</h3>
 <h4><span class="text-primary">Invoke the Boxstarter shell</span></h4>
-<img src="~/Images/shortcut.png">
+<img class="img-responsive" src="~/Images/shortcut.png">
 <p>The Boxstarter install creates a shortcut to a shell that provides the easiest way to access Boxstarter commands especially if you are not familiar with PowerShell. See <a href="~/UsingBoxstarter">Using Boxstarter Commands</a> for information about running Boxstarter in your own shell.</p>
 
 <h3>Step 4</h3>
@@ -95,4 +95,4 @@ Install-BoxstarterPackage -ComputerName MyMachine -PackageName NugetServer -Cred
 <h3>Step 9</h3>
 <h4><span class="text-primary">Run the application</span></h4>
 <p>Now we should be able to browse to our NuGet server application at http://MyServer</p>
-<img src="~/Images/NugetServerWeb.png">
+<img class="img-responsive" src="~/Images/NugetServerWeb.png">

--- a/Web/Learn/SimplePackage.cshtml
+++ b/Web/Learn/SimplePackage.cshtml
@@ -34,7 +34,7 @@ Install-WindowsUpdate -AcceptEula
 
 <h3>Step 3</h3>
 <h4><span class="text-primary">Invoke the Boxstarter shell</span></h4>
-<img src="~/Images/shortcut.png">
+<img class="img-responsive" src="~/Images/shortcut.png">
 <p>The Boxstarter install creates a shortcut to a shell that provides the easiest way to access Boxstarter commands especially if you are not familiar with PowerShell. See <a href="~/UsingBoxstarter">Using Boxstarter Commands</a> for information about running Boxstarter in your own shell.</p>
 
 <h3>Step 4</h3>

--- a/Web/Learn/WebLauncher.cshtml
+++ b/Web/Learn/WebLauncher.cshtml
@@ -38,15 +38,15 @@ cinst IIS-WebServerRole -source windowsfeatures
 </ul>
 
 <p>We'll stay simple here and save to a Github Gist.</p>
-<img src="~/images/gist1.png"/>
+<img class="img-responsive" src="~/images/gist1.png"/>
 
 <p/><p/>
 <p>After saving the Gist, we'll click the "View Raw" link</p>
-<img src="~/images/gist2.png"/>
+<img class="img-responsive" src="~/images/gist2.png"/>
 
 <p/><p/>
 <p>Now we will copy the raw URL:</p>
-<img src="~/images/gist3.png"/>
+<img class="img-responsive" src="~/images/gist3.png"/>
 
 <h3>Step 3</h3>
 <h4><span class="text-primary">Install the Boxstarter Modules</span></h4>

--- a/Web/Learn/_ContentLayout.cshtml
+++ b/Web/Learn/_ContentLayout.cshtml
@@ -30,11 +30,11 @@
     </div>
     <div class="col-sm-9" role="main">
         <div class="media">
-            <a class="pull-right" href="#">
-                <img class="media-object" src="~/images/boxlogo_sm.png" />
-            </a>
-            <div class="col-xs-12 col-md-8 media-body">
+            <div class="media-body">
                 @RenderSection("headerBody")
+            </div>
+            <div class="media-right">
+                <img class="media-object" src="~/images/boxlogo_sm.png" />
             </div>
         </div>
         @RenderBody()

--- a/Web/Learn/_ContentLayout.cshtml
+++ b/Web/Learn/_ContentLayout.cshtml
@@ -13,17 +13,25 @@
 
 
 <div class="row">
-    <div class="col-xs-6 col-sm-3 sidebar-offcanvas" id="sidebar" role="navigation">
-        <div class="list-group">
-            <a href="WebLauncher" class="list-group-item @PageData["weblauncherStyle"]">Run with a Gist</a>
-            <a href="SimplePackage" class="list-group-item @PageData["simplepackageStyle"]">Simple package creation</a>
-            <a href="RemotePackageWithArtifacts" class="list-group-item @PageData["remotepackageWithartifactsStyle"]">Deploying a web application remotely</a>
-        </div>
+    <div class="col-sm-3" id="sidebar">
+        <div class="navbar" role="navigation">
+            <button type="button" class="btn btn-secondary center-block visible-xs" data-toggle="collapse" data-target=".navbar-left">
+                Table of Contents
+                <span class="caret"></span>
+            </button>
+            <div class="navbar-collapse navbar-left px-0 collapse">
+                <div class="list-group">
+                    <a href="WebLauncher" class="list-group-item @PageData["weblauncherStyle"]">Run with a Gist</a>
+                    <a href="SimplePackage" class="list-group-item @PageData["simplepackageStyle"]">Simple package creation</a>
+                    <a href="RemotePackageWithArtifacts" class="list-group-item @PageData["remotepackageWithartifactsStyle"]">Deploying a web application remotely</a>
+                </div>
+            </div><!-- /.nav-collapse -->
+        </div><!-- /.navbar -->
     </div>
-    <div class="col-md-9" role="main">
+    <div class="col-sm-9" role="main">
         <div class="media">
             <a class="pull-right" href="#">
-                <img class="media-object" src="~/images/boxlogo_sm.png"/>
+                <img class="media-object" src="~/images/boxlogo_sm.png" />
             </a>
             <div class="col-xs-12 col-md-8 media-body">
                 @RenderSection("headerBody")

--- a/Web/TestingPackages.cshtml
+++ b/Web/TestingPackages.cshtml
@@ -29,7 +29,7 @@
     directory. The repository location can be found using the <code>$boxstarter</code>
     settings variable in <code>$Boxstarter.LocalRepo</code>.
 </p>
-<img src="Images/repoDir.png" />
+<img class="img-responsive" src="Images/repoDir.png" />
 <p>This location can be changed using the <code>Set-BoxstarterConfig</code> command.</p>
 <pre>Set-BoxStarterConfig -LocalRepo "c:\dev\Chocolatey-Packages"</pre>
 <p>
@@ -121,7 +121,7 @@ Test-BoxstarterPackage -PackageName "MyPackage1","MyPackage2"
     is greater than the published version, Boxstarter will initiate a test on
     the deployment targets otherwise the package test will be skipped.
 </p>
-<img src="Images/CI.png" />
+<img class="img-responsive" src="Images/CI.png" />
 <h3>Publishing Successful Packages</h3>
 <p>
     <code>Test-BoxstarterPackage</code> will return a set of test results. One can then use
@@ -271,7 +271,7 @@ Set-BoxstarterDeployOptions -DeploymentTargetCredentials $cred `
                     <code>AzureSubscriptionCertificate</code> - The Azure subscription certificate to use when using Azure VMs as deployment targets. This is the Base64 encoded content of the certificate and can be found in the ManagementCertificate attribute of your Azure publish settings file.
                 </li>
             </ul>
-            <img src="Images/tfs.png"/>
+            <img class="img-responsive" src="Images/tfs.png"/>
             <p>
                 NOTE: All of these MSBuild script parameters are optional for dedicated
                 builds as long as the values were provided in steps 2 and 3 above which

--- a/Web/UsingBoxstarter.cshtml
+++ b/Web/UsingBoxstarter.cshtml
@@ -32,10 +32,10 @@ PS C:\>
 <p>Or you can use the shortcuts installed to the desktop and start menu:</p>
 <div class="row">
     <div class="col-sm-2 col-md-2">
-            <img src="Images/shortcut.png">
+            <img class="img-responsive" src="Images/shortcut.png">
     </div>
     <div class="col-sm-10 col-md-4">
-            <img src="Images/shell.png">
+            <img class="img-responsive" src="Images/shell.png">
     </div>
 </div>
 <p>The remainder of the instructions on this page cover requirements to consider if using your own shell.</p>
@@ -54,7 +54,7 @@ PS C:\>
             <div class="caption">
                 <b>Windows 8</b>
             </div>
-            <img src="Images/win8admin.png">
+            <img class="img-responsive" src="Images/win8admin.png">
         </div>
     </div>
     <div class="col-sm-6 col-md-4">
@@ -62,7 +62,7 @@ PS C:\>
             <div class="caption">
                 <b>Windows 7</b>
             </div>
-            <img src="Images/win7admin.png">
+            <img class="img-responsive" src="Images/win7admin.png">
         </div>
     </div>
 </div>

--- a/Web/VMIntegration.cshtml
+++ b/Web/VMIntegration.cshtml
@@ -83,7 +83,7 @@ Install-WindowsFeature -name hyper-v -IncludeManagementTools
 <p>Before Windows Azure PowerShell can begin to manage your VMs, it needs your account information as well as authentication verification. This is incredibly easy, <b>only needs to be performed once</b> and involves just three commands:</p>
 <pre>Get-AzurePublishSettingsFile</pre>
 <p>This command will launch your default browser and initiate a Publisher Settings download. First you will land on the Windows Azure sign in page and as soon as you successfully authenticate, the download will begin.</p>
-<img src="images\publishAzure.png" />
+<img class="img-responsive" src="images\publishAzure.png" />
 <p>Now simply import the file just downloaded:</p>
 <pre>Import-AzurePublishSettingsFile -PublishSettingsFile C:\Users\Matt\Downloads\Subscription-1-1-19-2014-credentials.publishsettings</pre>
 <p>Finally, specify the name of the storage account you want to use. You can run <code>Get-AzureStorageAccount</code> for a list of all of your storage accounts.</p>

--- a/Web/WebLauncher.cshtml
+++ b/Web/WebLauncher.cshtml
@@ -51,15 +51,15 @@ cinst IIS-WebServerRole -source windowsfeatures
 </ul>
 
 <p>We'll stay simple here and save to a Github Gist.</p>
-<img src="images\gist1.png"/>
+<img class="img-responsive" src="images\gist1.png"/>
 
 <p/><p/>
 <p>After saving the Gist, we'll click the "View Raw" link</p>
-<img src="images\gist2.png"/>
+<img class="img-responsive" src="images\gist2.png"/>
 
 <p/><p/>
 <p>Now we will copy the raw URL:</p>
-<img src="images\gist3.png"/>
+<img class="img-responsive" src="images\gist3.png"/>
 
 <h3>Step 3</h3>
 <h4><span class="text-primary">Run the script</span></h4>
@@ -77,7 +77,7 @@ START https://boxstarter.org/package/nr/url?c:\temp\myscript.txt
 </pre>
 
 <p>This invokes a Boxstarter installer that will install everything according to your script. </p>
-<img src="images\install.png"/>
+<img class="img-responsive" src="images\install.png"/>
 
 <p>If not already installed, this will install Chocolatey and any of its prerequisites. If you did not include /nr/ in the Boxstarter URL, it will manage reboots and automatically log the machine back in so you do not have to attend to it throughout the installation.</p>
 

--- a/Web/_ContentLayout.cshtml
+++ b/Web/_ContentLayout.cshtml
@@ -11,24 +11,31 @@
     @RenderSection("styles", required: false)
 }
 
-
 <div class="row">
-    <div class="col-xs-6 col-sm-3 sidebar-offcanvas" id="sidebar" role="navigation">
-        <div class="list-group">
-            <a href="WhyBoxstarter" class="list-group-item @PageData["whyBoxstarterStyle"]">Why Boxstarter?</a>
-            <a href="InstallBoxstarter" class="list-group-item @PageData["installboxstarterStyle"]">Installing Boxstarter</a>
-            <a href="UsingBoxstarter" class="list-group-item @PageData["usingboxstarterStyle"]">Using Boxstarter Commands</a>
-            <a href="UnderstandingPackages" class="list-group-item @PageData["understandingpackagesStyle"]">Understanding Packages</a>
-            <a href="CreatingPackages" class="list-group-item @PageData["creatingpackagesStyle"]">Creating Packages</a>
-            <a href="PublishingPackages" class="list-group-item @PageData["publishingpackagesStyle"]">Publishing Packages</a>
-            <a href="InstallingPackages" class="list-group-item @PageData["installingpackagesStyle"]">Installing Packages</a>
-            <a href="VMIntegration" class="list-group-item @PageData["VMIntegrationStyle"]">Installing packages on a Virtual Machine</a>
-            <a href="TestingPackages" class="list-group-item @PageData["testingpackagesStyle"]">Testing Packages and Build Server Integration</a>
-            <a href="WinConfig" class="list-group-item @PageData["winconfigStyle"]">Boxstarter WinConfig Features</a>
-            <a href="BoxstarterResources" class="list-group-item @PageData["boxstarterresourcesStyle"]">More Boxstarter Resources</a>
-        </div>
+    <div class="col-sm-3" id="sidebar">
+        <div class="navbar" role="navigation">
+            <button type="button" class="btn btn-secondary center-block visible-xs" data-toggle="collapse" data-target=".navbar-left">
+                Table of Contents
+                <span class="caret"></span>
+            </button>
+            <div class="navbar-collapse navbar-left px-0 collapse">
+                <div class="list-group">
+                    <a href="WhyBoxstarter" class="list-group-item @PageData["whyBoxstarterStyle"]">Why Boxstarter?</a>
+                    <a href="InstallBoxstarter" class="list-group-item @PageData["installboxstarterStyle"]">Installing Boxstarter</a>
+                    <a href="UsingBoxstarter" class="list-group-item @PageData["usingboxstarterStyle"]">Using Boxstarter Commands</a>
+                    <a href="UnderstandingPackages" class="list-group-item @PageData["understandingpackagesStyle"]">Understanding Packages</a>
+                    <a href="CreatingPackages" class="list-group-item @PageData["creatingpackagesStyle"]">Creating Packages</a>
+                    <a href="PublishingPackages" class="list-group-item @PageData["publishingpackagesStyle"]">Publishing Packages</a>
+                    <a href="InstallingPackages" class="list-group-item @PageData["installingpackagesStyle"]">Installing Packages</a>
+                    <a href="VMIntegration" class="list-group-item @PageData["VMIntegrationStyle"]">Installing packages on a Virtual Machine</a>
+                    <a href="TestingPackages" class="list-group-item @PageData["testingpackagesStyle"]">Testing Packages and Build Server Integration</a>
+                    <a href="WinConfig" class="list-group-item @PageData["winconfigStyle"]">Boxstarter WinConfig Features</a>
+                    <a href="BoxstarterResources" class="list-group-item @PageData["boxstarterresourcesStyle"]">More Boxstarter Resources</a>
+                </div>
+            </div><!-- /.nav-collapse -->
+        </div><!-- /.navbar -->
     </div>
-    <div class="col-md-9" role="main">
+    <div class="col-sm-9" role="main">
         <div class="media">
             <a class="pull-right" href="#">
                 <img class="media-object" src="~/images/boxlogo_sm.png"/>

--- a/Web/_ContentLayout.cshtml
+++ b/Web/_ContentLayout.cshtml
@@ -37,11 +37,11 @@
     </div>
     <div class="col-sm-9" role="main">
         <div class="media">
-            <a class="pull-right" href="#">
-                <img class="media-object" src="~/images/boxlogo_sm.png"/>
-            </a>
-            <div class="col-xs-12 col-md-8 media-body">
+            <div class="media-body">
                 @RenderSection("headerBody")
+            </div>
+            <div class="media-right">
+                <img class="media-object" src="~/images/boxlogo_sm.png" />
             </div>
         </div>
         @RenderBody()

--- a/Web/_Sitelayout.cshtml
+++ b/Web/_Sitelayout.cshtml
@@ -33,6 +33,9 @@
             margin-top: 8px;
         }
 
+        .px-0 {
+            padding: 0;
+        }
         @RenderSection("styles", required: false)
     </style>
   </head>

--- a/Web/index.cshtml
+++ b/Web/index.cshtml
@@ -5,11 +5,11 @@
 @section featured {
 <div class="jumbotron">
     <div class="container">
-        <div class="media">
-            <a class="col-xs-12 col-md-3 pull-left" href="#">
-                <img height="270" class="media-object" src="images/boxlogo.png" width="270">
-            </a>
-            <div class="col-xs-12 col-md-8 media-body">
+        <div class="row">
+            <div class="col-sm-4">
+                <img class="img-responsive" src="images/boxlogo.png" />
+            </div>
+            <div class="col-sm-8">
                 <h1>Boxstarter</h1>
                 <p>Repeatable, <span class="text-primary"><b>reboot resilient</b></span> windows environment installations made easy using <a href="https://chocolatey.org">Chocolatey</a> packages. When its time to repave either <span class="text-primary"><b>bare metal or virtualized</b></span> instances, locally or on a <span class="text-primary"><b>remote machine</b></span>, Boxstarter can automate both trivial and highly complex installations. Compatible with all Windows versions from <span class="text-primary"><b>Windows 7/2008 R2 forward</b></span>.</p>
                 <p><a class="btn btn-primary btn-lg" role="button" href="downloads/Boxstarter.@(Helper.Version()).zip"><span class="glyphicon glyphicon-cloud-download"></span> Download v@(Helper.Version())</a></p>


### PR DESCRIPTION
This PR resolves issues #120, #183, #390 and also allows images to be responsive on mobile devices to prevent annoying horizontal scrollbars.

#### Fixes to Left Side Navigation (#120 & #183)
- When the viewport is <767px, the left side navigation will now collapse and be accessible through a button. 
- The Bootstrap columns were fixed as a result of this, and now the links are clickable on any viewport.

#### Fixes to Bootstrap classes within "Media" objects (#390)
- The classes "pull-left" and "pull-right" have been replaced with the appropriate classes as stated in the Bootstrap 3.4.1 documentation. 
- Extra "col-" classes have been removed as they are not allowed within "media" objects and could cause the layout to break

#### Responsive Images
- The class "img-responsive" has been added to most images, which makes them scalable on any viewport and removes any unnecessary horizontal scrollbars.
