### PR TITLE
(GH-343) Add PowerShell function naming convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,7 @@ Start with [Prerequisites](#prerequisites).
  * PowerShell must be CRLF and UTF-8. Git attributes are not used, so Git will not ensure this for you.
  * The minimum version of PowerShell this must work with is v2. This makes things somewhat more limited but compatible across the board for all areas Boxstarter is deployed. It is getting harder to find a reference for PowerShell v2, but this is a good one: http://adamringenberg.com/powershell2/table-of-contents/.
  * If you add a new file, also ensure you add it to the Visual Studio project and ensure it becomes an embedded resource.
+ * PowerShell function names should follow the `[Verb]-Boxstarter[Noun]` convention. If you are updating an existing function please rename it to this format and add an alias for the previous name to ensure backwards compatibility.
  * The last parameter in every function must be `[parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments`. This allows for future expansion and compatibility - as new parameters are introduced and used, it doesn't break older versions of Boxstarter.
  * Do not add new positional elements to functions. We want to promote using named parameters in calling functions.
  * Do not remove any existing positional elements from functions. We need to maintain compatibility with older versions of Boxstarter.


### PR DESCRIPTION
Update the PowerShell naming convention based on the discussion in #343 

Closes #343 