### PR TITLE
(GH-376) Add bootstrapper exception catch

### DIFF
--- a/BuildScripts/bootstrapper.ps1
+++ b/BuildScripts/bootstrapper.ps1
@@ -65,15 +65,20 @@ function Check-Chocolatey {
                 Write-Warning ".net install returned $exitCode. You likely need to reboot your computer before proceeding with the install."
                 return $false
             }
-            $env:ChocolateyInstall = "$env:programdata\chocolatey"
-            New-Item $env:ChocolateyInstall -Force -type directory | Out-Null
-            $url="https://chocolatey.org/api/v2/package/chocolatey/"
-            $wc=new-object net.webclient
-            $wp=[system.net.WebProxy]::GetDefaultProxy()
-            $wp.UseDefaultCredentials=$true
-            $wc.Proxy=$wp
-            iex ($wc.DownloadString("https://chocolatey.org/install.ps1"))
-            $env:path="$env:path;$env:ChocolateyInstall\bin"
+            try {
+                $env:ChocolateyInstall = "$env:programdata\chocolatey"
+                New-Item $env:ChocolateyInstall -Force -type directory | Out-Null
+                $url="https://chocolatey.org/api/v2/package/chocolatey/"
+                $wc=new-object net.webclient
+                $wp=[system.net.WebProxy]::GetDefaultProxy()
+                $wp.UseDefaultCredentials=$true
+                $wc.Proxy=$wp
+                iex ($wc.DownloadString("https://chocolatey.org/install.ps1"))
+                $env:path="$env:path;$env:ChocolateyInstall\bin"
+            }
+            catch {
+                return $false
+            }
         }
         else{
             return $false


### PR DESCRIPTION
If Boxstarter fails to download Chocolatey then it doesn't catch that failure and continues on with the rest of the bootstrapper script which will just start throwing misleading exceptions. Catch the failure and just end the script.

Closes #376 