### PR TITLE
(GH-424) Fix Set-TaskBarOptions function doc

### DIFF
--- a/Web/WinConfig.cshtml
+++ b/Web/WinConfig.cshtml
@@ -76,13 +76,13 @@ Set-WindowsExplorerOptions -DisableShowHiddenFilesFoldersDrives -DisableShowProt
 
 <h3>Set-BoxstarterTaskbarOptions</h3>
 <p>Sets options on the Windows Taskbar (formerly called Set-TaskbarOptions)</p>
-<p>AlwaysShowIconsOn/AlwaysShowIconsOff allows turning on or off always show all icons in the notification area</p>
+<p>AlwaysShowIconsOn/AlwaysShowIconsOff allows turning on or off always showing all icons in the notification area.</p>
 <pre>
-Set-BoxstarterTaskbarOptions -Size Small -Lock -Dock Top -Combine Always -AlwaysShowIconsOn -MultiMonitorOn -MultiMonitorMode All -MultiMonitorCombine Always
+Set-BoxstarterTaskbarOptions -Size Small -Dock Top -Combine Always -AlwaysShowIconsOn -MultiMonitorOn -MultiMonitorMode All -MultiMonitorCombine Always
 </pre>
 <p>It is also possible to do the converse actions, if required.</p>
 <pre>
-    Set-BoxstarterTaskbarOptions -Size Large -UnLock -Dock Bottom -Combine Never -AlwaysShowIconsOff -MultiMonitorOff
+Set-BoxstarterTaskbarOptions -Size Large -Dock Bottom -Combine Never -AlwaysShowIconsOff -MultiMonitorOff
 </pre>
 
 <h3>Update-ExecutionPolicy</h3>


### PR DESCRIPTION
Removes the `-Lock` and -`Unlock` parameters from the Set-TaskBarOptions function example as they cannot be used with the `-AlwaysShowIconsOn` or `-AlwaysShowIconsOff` parameters.

Fixes #424 