### PR TITLE
(GH-434) Fix disabling bing search for Win release 2004+

### DIFF
--- a/Boxstarter.WinConfig/Disable-BingSearch.ps1
+++ b/Boxstarter.WinConfig/Disable-BingSearch.ps1
@@ -1,19 +1,42 @@
-function Disable-BingSearch {
 <#
 .SYNOPSIS
-Disables the Bing Internet Search when searching from the search field in the Taskbar or Start Menu.
+Disables the Bing Internet Search when using the search field in the Taskbar or Start Menu.
+
+.DESCRIPTION
+Disables the Bing Internet Search when using the search field in the Taskbar or Start Menu.
+
+This is usable on all Windows versions pre and post Windows 2004 release (OS version 10.0.19041).
+
+.NOTES
+Boxstarter (https://boxstarter.org) (c) 2018 Chocolatey Software, Inc, 2012 - 2018 Matt Wrock.
 
 .LINK
 https://boxstarter.org
 https://www.privateinternetaccess.com/forum/discussion/18301/how-to-uninstall-core-apps-in-windows-10-and-miscellaneous
+https://www.lifehacker.com.au/2020/06/how-to-disable-bing-search-in-windows-10s-start-menu-2/
 
 #>
-    $path = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search"
+function Disable-BingSearch {
+    [CmdletBinding()]
+    Param()
 
-    if(!(Test-Path $path)) {
-        New-Item $path
+    $path = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search'
+    $windows2004AndLaterPath = 'HKCU:\Software\Policies\Microsoft\Windows\Explorer'
+    $windows2004Version = '10.0.19041'
+
+    $osVersion = (Get-CimInstance -ClassName Win32_OperatingSystem).Version
+    if ([version]$osVersion -ge [version]$windows2004Version) {
+        if (-not (Test-Path -Path $windows2004AndLaterPath)) {
+            $null = New-Item -Path $windows2004AndLaterPath
+        }
+
+        $null = New-ItemProperty -Path $windows2004AndLaterPath -Name 'DisableSearchBoxSuggestions' -Value 1 -PropertyType 'DWORD'
     }
+    else {
+        if( -not (Test-Path -Path $path)) {
+            $null = New-Item -Path $path
+        }
 
-    New-ItemProperty -LiteralPath $path -Name "BingSearchEnabled" -Value 0 -PropertyType "DWord" -ErrorAction SilentlyContinue
-    Set-ItemProperty -LiteralPath $path -Name "BingSearchEnabled" -Value 0
+        $null = New-ItemProperty -Path $path -Name "BingSearchEnabled" -Value 0 -PropertyType "DWORD"
+    }
 }

--- a/tests/WinConfig/Disable-BingSearch.tests.ps1
+++ b/tests/WinConfig/Disable-BingSearch.tests.ps1
@@ -1,0 +1,51 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Remove-Module boxstarter.*
+
+Resolve-Path $here\..\..\boxstarter.WinConfig\*.ps1 | ForEach-Object { . $_.ProviderPath }
+Resolve-Path $here\..\..\boxstarter.common\*.ps1 | ForEach-Object { . $_.ProviderPath }
+$Boxstarter.SuppressLogging = $true
+
+Describe "Disable-BingSearch" {
+
+    Context "When running on a specific Windows release" {
+
+        $testCases = @(
+            @{  OSVersion = '10.0.0'
+                KeyPath   = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search'
+                KeyName   = 'BingSearchEnabled'
+                KeyValue  = 0
+            }
+            @{ OSVersion = '10.0.19041'
+                KeyPath  = 'HKCU:\Software\Policies\Microsoft\Windows\Explorer'
+                KeyName  = 'DisableSearchBoxSuggestions'
+                KeyValue = 1
+            }
+            @{ OSVersion = '10.0.19042'
+                KeyPath  = 'HKCU:\Software\Policies\Microsoft\Windows\Explorer'
+                KeyName  = 'DisableSearchBoxSuggestions'
+                KeyValue = 1
+            }
+        )
+
+        It 'should create the appropriate registry path, key and value' -TestCases $testCases {
+            param ($OSVersion, $KeyPath, $KeyName, $KeyValue)
+
+            Mock Get-CimInstance -MockWith { [pscustomobject]@{ Version = $OSVersion } }
+            Mock New-Item  -Verifiable
+            Mock New-ItemProperty -Verifiable
+            if (Test-Path -Path $KeyPath) {
+                $assertTimesCalled = 0
+            }
+            else {
+                $assertTimesCalled = 1
+            }
+
+            Disable-BingSearch
+            Assert-MockCalled -CommandName 'Get-CimInstance' -Exactly 1 -Scope It
+            Assert-MockCalled -CommandName 'New-Item' -ParameterFilter { $Path -eq $KeyPath } -Exactly $assertTimesCalled -Scope It
+            Assert-MockCalled -CommandName 'New-ItemProperty' `
+                -ParameterFilter { $Path -eq $KeyPath `
+                    -and $Name -eq $KeyName -and $Value -eq $KeyValue } -Exactly 1 -Scope It
+        } #it
+    } #context
+}


### PR DESCRIPTION
## Description
In Windows release 2004 the registry key to disable bing search in the taskbar and start menu has changed.

## Related Issue
Fixes #434

## Motivation and Context
It disables Bing Search across all Windows platforms.

## How Has This Been Tested?
This was tested on a Windows 10 2004 system. It was also tested with the Pester tests that are included as part of the commit.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
