### PR TITLE
(GH-426) Pin Pester 4 version

### DIFF
--- a/BuildScripts/build.ps1
+++ b/BuildScripts/build.ps1
@@ -12,7 +12,7 @@ if(-not $env:ChocolateyInstall -or -not (Test-Path "$env:ChocolateyInstall")){
 
 if(!(Test-Path $env:ChocolateyInstall\lib\Psake*)) { cinst psake -y --no-progress }
 if(!(Test-Path $env:ChocolateyInstall\lib\7zip.CommandLine*)) { cinst 7zip.CommandLine -y --no-progress }
-if(!(Test-Path $env:ChocolateyInstall\lib\pester*)) { cinst pester -y --no-progress }
+if(!(Test-Path $env:ChocolateyInstall\lib\pester*)) { cinst pester --version 4.10.1 -y --no-progress }
 if(!(Test-Path $env:ChocolateyInstall\lib\AzurePowershell*)) { cinst AzurePowershell -y --no-progress }
 if(!(Test-Path $env:ChocolateyInstall\lib\WindowsAzureLibsForNet*)) { cinst WindowsAzureLibsForNet --version 2.5 -y --no-progress }
 if(!(Test-Path $env:ChocolateyInstall\bin\nuget.exe)) { cinst nuget.commandline -y --no-progress }


### PR DESCRIPTION
## Description
The Pester tests fail to run (locally) if Pester v5 is installed. Pin Pester to latest version 4.

## Related Issue
#426 

## Motivation and Context
This allows the Pester tests to run locally. And will also run when the in the automated build (when they are enabled).

## How Has This Been Tested?
While working on #438 I noticed the Pester tests were failing as I had Pester v5 installed. When switching to Pester v4 everything worked as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
