### PR TITLE
(GH-443) Adds Windows Explorer item check box view

### DIFF
--- a/Boxstarter.WinConfig/Set-WindowsExplorerOptions.ps1
+++ b/Boxstarter.WinConfig/Set-WindowsExplorerOptions.ps1
@@ -63,6 +63,12 @@ Enables Windows snap feature (side by side application selection tool).
 .PARAMETER DisableSnapAssist
 Disables Windows snap feature (side by side application selection tool).
 
+.PARAMETER EnableItemCheckBoxes
+Enables the showing of check boxes next to items in Windows Explorer for item selection
+
+.PARAMETER DisableItemCheckBoxes
+Disables the showing of check boxes next to items in Windows Explorer for item selection.
+
 .LINK
 https://boxstarter.org
 
@@ -89,7 +95,9 @@ https://boxstarter.org
         [switch]$EnableShowRibbon,
         [switch]$DisableShowRibbon,
         [switch]$EnableSnapAssist,
-        [switch]$DisableSnapAssist
+        [switch]$DisableSnapAssist,
+        [switch]$EnableItemCheckBoxes,
+        [switch]$DisableItemCheckBoxes
     )
 
     $PSBoundParameters.Keys | % {
@@ -133,6 +141,9 @@ https://boxstarter.org
 
         if($EnableSnapAssist) {Set-ItemProperty $advancedKey SnapAssist 1}
         if($DisableSnapAssist) {Set-ItemProperty $advancedKey SnapAssist 0}
+
+        if($EnableItemCheckBoxes) {Set-ItemProperty $advancedKey AutoCheckSelect 1}
+        if($DisableItemCheckBoxes) {Set-ItemProperty $advancedKey AutoCheckSelect 0}
     }
 
     if(Test-Path -Path $cabinetStateKey) {

--- a/Web/WinConfig.cshtml
+++ b/Web/WinConfig.cshtml
@@ -67,11 +67,11 @@ Set-CornerNavigationOptions -DisableUpperRightCornerShowCharms -DisableUpperLeft
 <h3>Set-WindowsExplorerOptions</h3>
 <p>Sets options on the Windows Explorer shell</p>
 <pre>
-Set-WindowsExplorerOptions -EnableShowHiddenFilesFoldersDrives -EnableShowProtectedOSFiles -EnableShowFileExtensions -EnableShowFullPathInTitleBar -EnableOpenFileExplorerToQuickAccess -EnableShowRecentFilesInQuickAccess -EnableShowFrequentFoldersInQuickAccess -EnableExpandToOpenFolder -EnableShowRibbon
+Set-WindowsExplorerOptions -EnableShowHiddenFilesFoldersDrives -EnableShowProtectedOSFiles -EnableShowFileExtensions -EnableShowFullPathInTitleBar -EnableOpenFileExplorerToQuickAccess -EnableShowRecentFilesInQuickAccess -EnableShowFrequentFoldersInQuickAccess -EnableExpandToOpenFolder -EnableShowRibbon -EnableItemCheckBoxes
 </pre>
 <p>It is also possible to do the converse actions, if required.</p>
 <pre>
-Set-WindowsExplorerOptions -DisableShowHiddenFilesFoldersDrives -DisableShowProtectedOSFiles -DisableShowFileExtensions -DisableShowFullPathInTitleBar -DisableOpenFileExplorerToQuickAccess -DisableShowRecentFilesInQuickAccess -DisableShowFrequentFoldersInQuickAccess -DisableExpandToOpenFolder -DisableShowRibbon
+Set-WindowsExplorerOptions -DisableShowHiddenFilesFoldersDrives -DisableShowProtectedOSFiles -DisableShowFileExtensions -DisableShowFullPathInTitleBar -DisableOpenFileExplorerToQuickAccess -DisableShowRecentFilesInQuickAccess -DisableShowFrequentFoldersInQuickAccess -DisableExpandToOpenFolder -DisableShowRibbon -DisableItemCheckBoxes
 </pre>
 
 <h3>Set-BoxstarterTaskbarOptions</h3>


### PR DESCRIPTION
Even though Boxstarter has existing functionality to modify Windows
Explorer's settings, the existing functionality did not allow for user's to configure the "Use check boxes to select items" setting.  This commit adds that functionality to the existing set-windowsexploreroptions function.

Boxstarter will continue to work even if this change is not implemented, as this change is meant as an enhancement, not a bug fix.


## Description
I modified the Set-WindowsExplorerOptions.ps1 file in the following ways:
- Added two additional parameters that follow the same naming convention of all of the other parameters: "EnableItemCheckBoxes" and "DisableItemCheckBoxes"
- Added comment based help entries for each parameter describing their functionality
- Added two lines of code which would configure the check box settings for Windows Explorer

I also modified the WinConfig.cshtml file by modifying the two "Set-WindowsExplorerOptions" function examples to include each new parameter.


## Related Issue

Fixes #443 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

1. I spun up a fresh windows 10 vm
2. installed boxstarter
3. Replaced the contents of set-windowsexploreroptions in Boxstarter.Winconfig module with the modified script
4. wrote a one line boxstarter script using the command
5. Passed the script as an argument to install-boxstarterpackage

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.
