### PR TITLE
(GH-448) Add extra metadata to nuspec files

### DIFF
--- a/BuildScripts/default.ps1
+++ b/BuildScripts/default.ps1
@@ -26,7 +26,7 @@ properties {
 Task default -depends Build
 Task Build -depends Run-GitVersion, Build-Clickonce, Build-Web, Install-ChocoPkg, Test, Package
 Task Deploy -depends Build, Deploy-DownloadZip, Deploy-Bootstrapper, Publish-Clickonce -description 'Versions, packages and pushes'
-Task Package -depends Clean-Artifacts, Version-Module, Install-ChocoPkg, Create-ModuleZipForRemoting, Pack-NuGet, Package-DownloadZip -description 'Versions the psd1 and packs the module and example package'
+Task Package -depends Clean-Artifacts, Version-Module, Install-ChocoPkg, Create-ModuleZipForRemoting, Pack-Chocolatey, Package-DownloadZip -description 'Versions the psd1 and packs the module and example package'
 Task Push-Public -depends Push-Chocolatey
 Task All-Tests -depends Test, Integration-Test
 Task Quick-Deploy -depends Run-GitVersion, Build-Clickonce, Build-web, Package, Deploy-DownloadZip, Deploy-Bootstrapper, Publish-Clickonce
@@ -122,7 +122,7 @@ task Publish-ClickOnce -depends Install-MSBuild {
     Copy-Item "$basedir\Boxstarter.Clickonce\bin\Debug\App.Publish\*" "$basedir\web\Launch" -Recurse -Force
 }
 
-Task Test -depends Install-ChocoPkg, Pack-NuGet, Create-ModuleZipForRemoting {
+Task Test -depends Install-ChocoPkg, Pack-Chocolatey, Create-ModuleZipForRemoting {
     Push-Location "$baseDir"
     $pesterDir = "$env:ChocolateyInstall\lib\Pester"
     $pesterTestResultsFile = "$baseDir\buildArtifacts\TestResults.xml"
@@ -147,7 +147,7 @@ Task Test -depends Install-ChocoPkg, Pack-NuGet, Create-ModuleZipForRemoting {
     Pop-Location
 }
 
-Task Integration-Test -depends Pack-NuGet, Create-ModuleZipForRemoting {
+Task Integration-Test -depends Pack-Chocolatey, Create-ModuleZipForRemoting {
     Push-Location "$baseDir"
     $pesterDir = "$env:ChocolateyInstall\lib\Pester"
     if($testName){
@@ -188,7 +188,7 @@ Task Clean-Artifacts {
     mkdir "$baseDir\buildArtifacts\tempNuGetFolders\Boxstarter.WinConfig"
 }
 
-Task Pack-NuGet -depends Sign-PowerShellFiles -description 'Packs the modules and example packages' {
+Task Pack-Chocolatey -depends Sign-PowerShellFiles -description 'Packs the modules and example packages' {
     if (Test-Path "$baseDir\buildPackages\*.nupkg") {
       Remove-Item "$baseDir\buildPackages\*.nupkg" -Force
     }
@@ -307,7 +307,7 @@ function PackDirectory($path, $Version = $version){
     exec {
         Get-ChildItem $path -Recurse -include *.nuspec |
             ForEach-Object {
-                 .$nugetExe pack $_ -OutputDirectory $path -NoPackageAnalysis -version $Version
+                 choco pack $_ --OutputDirectory $path --version $version
               }
     }
 }

--- a/BuildScripts/nuget/Boxstarter.Azure.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Azure.nuspec
@@ -10,6 +10,10 @@
     <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <summary>Azure support for Boxstarter</summary>
+    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
     <description>Boxstarter's Azure module includes functionality for targeting Azure VMs with the ability to save and restore checkpoints leveraging blob snapshots.
 
 ## Package parameters
@@ -19,7 +23,7 @@
     <tags>Boxstarter bootstrapper environment setup VM virtualization Azure</tags>
     <dependencies>
       <dependency id="Boxstarter" version="[$version$]" />
-      <dependency id="WindowsAzurePowershell" />
+      <dependency id="WindowsAzurePowershell" version="1.6.0.20180408" />
     </dependencies>
     <releaseNotes>
 See information here: https://github.com/chocolatey/boxstarter/releases

--- a/BuildScripts/nuget/Boxstarter.Bootstrapper.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Bootstrapper.nuspec
@@ -10,6 +10,10 @@
     <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <summary>Bootstrapper module for Boxstarter</summary>
+    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
     <description>Boxstarter's Bootstrapper module provides a PowerShell wrapper that supports reboots and automatic logons and exposes commands that can detect pending reboots, perform logging and messaging, and several commands that can configure various windows settings.
 
 ## Package parameters

--- a/BuildScripts/nuget/Boxstarter.Chocolatey.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Chocolatey.nuspec
@@ -10,6 +10,10 @@
     <title>Boxstarter Chocolatey Module</title>
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <summary>Chocolatey module for Boxstarter</summary>
+    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
     <description>Creates a fresh developer (or non developer) environment from a bare OS utilizing PowerShell and Chocolatey. Installs Chocolatey, cutomizes windows settings, installs windows updates, handles reboots, installs windows features and your favorite applications.
 
 ## Package parameters

--- a/BuildScripts/nuget/Boxstarter.Common.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Common.nuspec
@@ -11,6 +11,10 @@
     <iconUrl>https://raw.githubusercontent.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
     <title>Boxstarter Common Module</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>Common module for Boxstarter</summary>
+    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
     <description>Provides common functions used by multiple Boxstarter Modules.
 
 ## Package parameters

--- a/BuildScripts/nuget/Boxstarter.HyperV.nuspec
+++ b/BuildScripts/nuget/Boxstarter.HyperV.nuspec
@@ -10,6 +10,10 @@
     <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <summary>Hyper-V support for Boxstarter</summary>
+    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
     <description>Boxstarter's HyperV module includes functionality for targeting Hyper-V guest VMs with the ability to automatically configure them for remote installation and to create or restore snapshots at installation time.
 
 ## Package parameters

--- a/BuildScripts/nuget/Boxstarter.TestRunner.nuspec
+++ b/BuildScripts/nuget/Boxstarter.TestRunner.nuspec
@@ -10,6 +10,10 @@
     <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <summary>Test runner module for Boxstarter</summary>
+    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
     <description>Boxstarter's Test Runner module makes it easy to automate the testing and publishing of Chocolatey packages.
 ## Package parameters
 

--- a/BuildScripts/nuget/Boxstarter.WinConfig.nuspec
+++ b/BuildScripts/nuget/Boxstarter.WinConfig.nuspec
@@ -11,6 +11,10 @@
     <title>Boxstarter WinConfig Module</title>
     <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>Windows environment module for Boxstarter</summary>
+    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
     <description>Functions that Boxstarter uses to customize the windows environment.
 
 ## Package parameters

--- a/BuildScripts/nuget/Boxstarter.nuspec
+++ b/BuildScripts/nuget/Boxstarter.nuspec
@@ -11,6 +11,10 @@
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <description>Repeatable, reboot resilient windows environment installations made easy using Chocolatey packages. When its time to repave either bare metal or virtualized instances, locally or on a remote machine, Boxstarter can automate both trivial and highly complex installations. Compatible with all Windows versions from Windows 7/2008 R2 forward.</description>
+    <summary>Boxstarter provides repeatable, reboot resilient installs</summary>
+    <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>
+    <projectSourceUrl>https://github.com/chocolatey/boxstarter/</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/chocolatey/boxstarter/issues</bugTrackerUrl>
     <tags>Boxstarter environment setup</tags>
     <dependencies>
       <dependency id="Boxstarter.Common" version="[$version$]" />


### PR DESCRIPTION
## Description

Add missing metadata to nuspec files so there are less validation warnings when packages are submitted to Chocolatey public repo.

## Related Issue

Resolves #448

## Motivation and Context
Nicer Chocolatey packages

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
