### PR TITLE
(GH-451) Fix Boxstarter Package Parameter '-StopOnPackageFailure'

### DIFF
--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -149,29 +149,30 @@ function chocolatey {
     Write-BoxstarterMessage "Will stop on first package error: $stopOnFirstError" -Verbose
 
     $rebootCodes = Get-PassedArg -ArgumentName 'RebootCodes' -OriginalArgs $args
-    # if a 'pure Boxstarter' parameter has been specified, 
-    # we need to remove it from the command line arguments that 
-    # will be passed to Chocolatey, as only Boxstarter is able to handle it
-    if ($null -ne $rebootCodes) {
-        $argsWithoutBoxstarterSpecials = @()
-        $skipNextArg = $false
-        foreach ($a in $args) {
-            if ($skipNextArg) {
-                $skipNextArg = $false;
-                continue;
-            }
+    
+    $argsWithoutBoxstarterSpecials = @()
+    $skipNextArg = $false
 
-            if (@("-RebootCodes", "--RebootCodes") -contains $a) {
-                $skipNextArg = $true
-                continue;
-            }
-            if (@("-StopOnPackageFailure", "--StopOnPackageFailure") -contains $a) {
-                continue;
-            }
-            $argsWithoutBoxstarterSpecials += $a
+    foreach ($a in $args) {
+        if ($skipNextArg) {
+            $skipNextArg = $false;
+            continue;
         }
-        $args = $argsWithoutBoxstarterSpecials
+
+        # if a 'pure Boxstarter' parameter has been specified, 
+        # we need to remove it from the command line arguments that 
+        # will be passed to Chocolatey, as only Boxstarter is able to handle it
+        if ($a -match "^--?RebootCodes") {
+            $skipNextArg = $true
+            continue;
+        }
+        if ($a -match "^--?StopOnPackageFailure") {
+            continue;
+        }
+        $argsWithoutBoxstarterSpecials += $a
     }
+
+    $args = $argsWithoutBoxstarterSpecials
     $rebootCodes = Add-DefaultRebootCodes -Codes $rebootCodes
     Write-BoxstarterMessage "RebootCodes: '$rebootCodes' ($($rebootCodes.Count) elements)" -Verbose
 

--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -162,11 +162,11 @@ function chocolatey {
         # if a 'pure Boxstarter' parameter has been specified, 
         # we need to remove it from the command line arguments that 
         # will be passed to Chocolatey, as only Boxstarter is able to handle it
-        if ($a -match "^--?RebootCodes") {
+        if ($a -match "^--?RebootCodes$") {
             $skipNextArg = $true
             continue;
         }
-        if ($a -match "^--?StopOnPackageFailure") {
+        if ($a -match "^--?StopOnPackageFailure$") {
             continue;
         }
         $argsWithoutBoxstarterSpecials += $a

--- a/tests/Chocolatey/Chocolatey.tests.ps1
+++ b/tests/Chocolatey/Chocolatey.tests.ps1
@@ -472,6 +472,27 @@ Describe "Call-Chocolatey" {
             $passedArgs[4] | Should Be "blah"
         }
     }
+
+    context "package parameters - Boxstarter exclusive parameters are stripped (single param)" {
+        $script:passedArgs = ""
+        Mock Invoke-LocalChocolatey { $script:passedArgs = $chocoArgs }
+
+        choco Install -y pkg --source blah --StopOnPackageFailure
+
+        $passedArgs | Should Not BeNullOrEmpty
+
+        it "passes expected params" {
+            $passedArgs.count | Should Be 5
+        }
+        it "passes all parameters in correct order" {
+            $passedArgs[0] | Should Be "Install"
+            $passedArgs[1] | Should Be "pkg" # package will always be first argument (reordering happens!)
+            $passedArgs[2] | Should Be "-y" # passed -y is after package because of the reordering
+            $passedArgs[3] | Should Be "--source"
+            $passedArgs[4] | Should Be "blah"
+        }
+    }
+
 }
 
 Describe "Get-PackageNamesFromInvocationLine" {


### PR DESCRIPTION

## Description
In the code that evaluates Boxstarter Package Parameters, 'StopOnPackagaFailure' is only recognized (and therefore stripped from the 'chocolatey parameter string) if, and only if 'RebootCodes' were present in the original parameter string.

## Related Issue
Fixes #451

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
