### PR TITLE
(GH-488) Add TeamCity build config

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Boxstarter Config DSL Script</name>
+  <groupId>Boxstarter</groupId>
+  <artifactId>Boxstarter_dsl</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.jetbrains.teamcity</groupId>
+    <artifactId>configs-dsl-kotlin-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <repositories>
+    <repository>
+      <id>jetbrains-all</id>
+      <url>https://download.jetbrains.com/teamcity-repository</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>teamcity-server</id>
+      <url>https://teamcityserver/app/dsl-plugins-repository</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>JetBrains</id>
+      <url>https://download.jetbrains.com/teamcity-repository</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <sourceDirectory>${basedir}</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <version>${kotlin.version}</version>
+
+        <configuration/>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>process-test-sources</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jetbrains.teamcity</groupId>
+        <artifactId>teamcity-configs-maven-plugin</artifactId>
+        <version>${teamcity.dsl.version}</version>
+        <configuration>
+          <format>kotlin</format>
+          <dstDir>target/generated-configs</dstDir>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.teamcity</groupId>
+      <artifactId>configs-dsl-kotlin</artifactId>
+      <version>${teamcity.dsl.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.teamcity</groupId>
+      <artifactId>configs-dsl-kotlin-plugins</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>pom</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-script-runtime</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,0 +1,77 @@
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+
+/*
+The settings script is an entry point for defining a TeamCity
+project hierarchy. The script should contain a single call to the
+project() function with a Project instance or an init function as
+an argument.
+
+VcsRoots, BuildTypes, Templates, and subprojects can be
+registered inside the project using the vcsRoot(), buildType(),
+template(), and subProject() methods respectively.
+
+To debug settings scripts in command-line, run the
+
+    mvnDebug org.jetbrains.teamcity:teamcity-configs-maven-plugin:generate
+
+command and attach your debugger to the port 8000.
+
+To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
+-> Tool Windows -> Maven Projects), find the generate task node
+(Plugins -> teamcity-configs -> teamcity-configs:generate), the
+'Debug' option is available in the context menu for the task.
+*/
+
+version = "2021.2"
+
+project {
+
+    vcsRoot(HttpsGithubComChocolateyBoxstarterGitRefsHeadsMaster)
+
+    buildType(Build)
+}
+
+object Build : BuildType({
+    name = "Build"
+
+    artifactRules = "buildArtifacts => buildArtifacts"
+
+    vcs {
+        root(HttpsGithubComChocolateyBoxstarterGitRefsHeadsMaster)
+    }
+
+    steps {
+        powerShell {
+            name = "Prerequisites"
+            scriptMode = script {
+                content = """
+                    if ((Get-WindowsFeature -Name NET-Framework-Core).InstallState -ne 'Installed') {
+                        Install-WindowsFeature -Name NET-Framework-Core
+                    }
+                """.trimIndent()
+            }
+        }
+        powerShell {
+            name = "Build"
+            scriptMode = file {
+                path = "BuildScripts/build.ps1"
+            }
+            param("jetbrains_powershell_scriptArguments", "quick-deploy")
+        }
+    }
+
+    triggers {
+        vcs {
+        }
+    }
+})
+
+object HttpsGithubComChocolateyBoxstarterGitRefsHeadsMaster : GitVcsRoot({
+    name = "https://github.com/chocolatey/boxstarter.git#refs/heads/master"
+    url = "https://github.com/chocolatey/boxstarter.git"
+    branch = "refs/heads/master"
+    branchSpec = "refs/heads/*"
+})

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -28,9 +28,6 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 version = "2021.2"
 
 project {
-
-    vcsRoot(HttpsGithubComChocolateyBoxstarterGitRefsHeadsMaster)
-
     buildType(Build)
 }
 
@@ -40,7 +37,7 @@ object Build : BuildType({
     artifactRules = "buildArtifacts => buildArtifacts"
 
     vcs {
-        root(HttpsGithubComChocolateyBoxstarterGitRefsHeadsMaster)
+        root(DslContext.settingsRoot)
     }
 
     steps {
@@ -52,6 +49,14 @@ object Build : BuildType({
                         Install-WindowsFeature -Name NET-Framework-Core
                     }
                 """.trimIndent()
+            }
+        }
+        step {
+            name = "Include Signing Keys"
+            type = "PrepareSigningEnvironment"
+
+            conditions {
+                equals("teamcity.build.branch.is_default", "true")
             }
         }
         powerShell {
@@ -67,11 +72,4 @@ object Build : BuildType({
         vcs {
         }
     }
-})
-
-object HttpsGithubComChocolateyBoxstarterGitRefsHeadsMaster : GitVcsRoot({
-    name = "https://github.com/chocolatey/boxstarter.git#refs/heads/master"
-    url = "https://github.com/chocolatey/boxstarter.git"
-    branch = "refs/heads/master"
-    branchSpec = "refs/heads/*"
 })


### PR DESCRIPTION
## Description
This PR add TeamCity build configuration for this project which can be imported into a TeamCity server using the [Versioned Settings](https://www.jetbrains.com/help/teamcity/storing-project-settings-in-version-control.html) feature.

## Related Issue
Fixes #488 

## Motivation and Context
Storing TeamCity build configuration next to the code it is building and in soruce control itself for change tracking, etc.

## How Has This Been Tested?
This has been tested against an available test TeamCity server.

Build steps were observed to have been imported, and the build could be run and suceeded.

## Types of changes
Enhancement: Doesn't touch the project code itself, isn't a breaking change, doesn't _technically_ fix a bug.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. **(N/A)**
- [ ] I have updated the documentation accordingly. **(N/A)**
- [x] I have read the [**CONTRIBUTING**](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes. **(N/A)**
- [ ] All new and existing tests passed. **(N/A)**
