### PR TITLE
(#491) Add disable / enable taskbar search box

### DIFF
--- a/Boxstarter.WinConfig/Set-BoxstarterTaskbarOptions.ps1
+++ b/Boxstarter.WinConfig/Set-BoxstarterTaskbarOptions.ps1
@@ -112,9 +112,18 @@ multi-monitor support and always combine icons on non-primary monitors.
         [Parameter(ParameterSetName='MultiMonitorOn')]
         [ValidateSet('Always','Full','Never')]
         [String]
-        $MultiMonitorCombine
+        $MultiMonitorCombine,
+
+        [Parameter(ParameterSetName = 'DisableSearchBox')]
+        [switch]
+        $DisableSearchBox,
+
+        [Parameter(ParameterSetName = 'EnableSearchBox')]
+        [switch]
+        $EnableSearchBox
     )
 
+    $baseKey = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion'
     $explorerKey = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer'
     $key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced'
     $settingKey = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\StuckRects2'
@@ -234,6 +243,15 @@ multi-monitor support and always combine icons on non-primary monitors.
         if ($alwaysShowIconsOff) {
             Set-ItemProperty -Path $explorerKey -Name 'EnableAutoTray' -Value 1
         }
+    }
+
+    if ($EnableSearchBox.IsPresent) {
+        # this will create the path if it doesn't exist
+        Set-ItemProperty -Path (Join-Path -Path $baseKey -ChildPath 'Search') -Name 'SearchBoxTaskbarMode' -Value 2 -Type DWord -Force
+    }
+    elseif ($DisableSearchBox.IsPresent) {
+        # this will create the path if it does not exist
+        Set-ItemProperty -Path (Join-Path -Path $baseKey -ChildPath 'Search') -Name 'SearchBoxTaskbarMode' -Value 0 -Type DWord -Force
     }
 
     Restart-Explorer

--- a/Web/WinConfig.cshtml
+++ b/Web/WinConfig.cshtml
@@ -78,11 +78,11 @@ Set-WindowsExplorerOptions -DisableShowHiddenFilesFoldersDrives -DisableShowProt
 <p>Sets options on the Windows Taskbar (formerly called Set-TaskbarOptions)</p>
 <p>AlwaysShowIconsOn/AlwaysShowIconsOff allows turning on or off always showing all icons in the notification area.</p>
 <pre>
-Set-BoxstarterTaskbarOptions -Size Small -Dock Top -Combine Always -AlwaysShowIconsOn -MultiMonitorOn -MultiMonitorMode All -MultiMonitorCombine Always
+Set-BoxstarterTaskbarOptions -Size Small -Dock Top -Combine Always -AlwaysShowIconsOn -MultiMonitorOn -MultiMonitorMode All -MultiMonitorCombine Always -EnableSearchBox
 </pre>
 <p>It is also possible to do the converse actions, if required.</p>
 <pre>
-Set-BoxstarterTaskbarOptions -Size Large -Dock Bottom -Combine Never -AlwaysShowIconsOff -MultiMonitorOff
+Set-BoxstarterTaskbarOptions -Size Large -Dock Bottom -Combine Never -AlwaysShowIconsOff -MultiMonitorOff -DisableSearchBox
 </pre>
 
 <h3>Update-ExecutionPolicy</h3>


### PR DESCRIPTION
## Description
Added the ability to enable / disable the search box on the Windows 10 taskbar.

## Related Issue
Fixes #491 

## Motivation and Context
Allows further customisation of the Windows taskbar.

## How Has This Been Tested?
This has been run in the Boxstarter shell on a clean Windows 10 sandbox.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
