### PR TITLE
(GH-493)(CU-ENGTASKS-505) Enable signing from local certificate store

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -39,6 +39,10 @@ object Build : BuildType({
         web => web-%system.build.number%.zip
     """.trimIndent()
 
+    params {
+        param("env.CERT_SUBJECT_NAME", "Chocolatey Software, Inc.")
+    }
+
     vcs {
         root(DslContext.settingsRoot)
     }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -34,7 +34,10 @@ project {
 object Build : BuildType({
     name = "Build"
 
-    artifactRules = "buildArtifacts => buildArtifacts"
+    artifactRules = """
+        buildArtifacts => buildArtifacts
+        web => web-%system.build.number%.zip
+    """.trimIndent()
 
     vcs {
         root(DslContext.settingsRoot)

--- a/Boxstarter.ClickOnce/Boxstarter.WebLaunch.csproj
+++ b/Boxstarter.ClickOnce/Boxstarter.WebLaunch.csproj
@@ -140,6 +140,7 @@
   <PropertyGroup>
     <PostBuildEvent Condition="Exists($(CHOCOLATEY_OFFICIAL_CERT))">set /p CertificatePassword=&lt;%25CHOCOLATEY_OFFICIAL_CERT_PASSWORD%25
 "$(WindowsSDK80Path)bin\x64\signtool.exe" sign /f %25CHOCOLATEY_OFFICIAL_CERT%25 /p %25CertificatePassword%25 "$(ProjectDir)obj\debug\Boxstarter.WebLaunch.exe"</PostBuildEvent>
+    <PostBuildEvent Condition="'$(STORE_CHOCOLATEY_OFFICIAL_CERT)' == 'true' or '$(STORE_DEVTEST_CERT)' == 'true'">"$(WindowsSDK80Path)bin\x64\signtool.exe" sign /sm /n "%25CERT_SUBJECT_NAME%25" "$(ProjectDir)obj\debug\Boxstarter.WebLaunch.exe"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Boxstarter.ClickOnce/Boxstarter.WebLaunch.csproj
+++ b/Boxstarter.ClickOnce/Boxstarter.WebLaunch.csproj
@@ -139,8 +139,8 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent Condition="Exists($(CHOCOLATEY_OFFICIAL_CERT))">set /p CertificatePassword=&lt;%25CHOCOLATEY_OFFICIAL_CERT_PASSWORD%25
-"$(WindowsSDK80Path)bin\x64\signtool.exe" sign /f %25CHOCOLATEY_OFFICIAL_CERT%25 /p %25CertificatePassword%25 "$(ProjectDir)obj\debug\Boxstarter.WebLaunch.exe"</PostBuildEvent>
-    <PostBuildEvent Condition="'$(STORE_CHOCOLATEY_OFFICIAL_CERT)' == 'true' or '$(STORE_DEVTEST_CERT)' == 'true'">"$(WindowsSDK80Path)bin\x64\signtool.exe" sign /sm /n "%25CERT_SUBJECT_NAME%25" "$(ProjectDir)obj\debug\Boxstarter.WebLaunch.exe"</PostBuildEvent>
+"$(WindowsSDK80Path)bin\x64\signtool.exe" sign /t "http://timestamp.digicert.com" /f %25CHOCOLATEY_OFFICIAL_CERT%25 /p %25CertificatePassword%25 "$(ProjectDir)obj\debug\Boxstarter.WebLaunch.exe"</PostBuildEvent>
+    <PostBuildEvent Condition="'$(STORE_CHOCOLATEY_OFFICIAL_CERT)' == 'true' or '$(STORE_DEVTEST_CERT)' == 'true'">"$(WindowsSDK80Path)bin\x64\signtool.exe" sign /t "http://timestamp.digicert.com" /sm /n "%25CERT_SUBJECT_NAME%25" "$(ProjectDir)obj\debug\Boxstarter.WebLaunch.exe"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
## Description

The main change in this PR is enabling the signing of the ClickOnce and PowerShell files using a certificate stored in the local certificate store rather than a PFX file on disk.

In completing these changes, I noted that the ClickOnce signing didn't include a timestamp, so I have added this.

For completeness of TeamCity builds, I have also specified that the web directory should be collected as a compressed archive artifact.

## Related Issue

Fixes #493

## Motivation and Context

Signing certificates aren't always available as PFX files, and supporting the certificate store allows for that use case. This change adds a second signing method so as to not break existing builds that are using a PFX file.

## How Has This Been Tested?

These changes have been synced through to a development TeamCity server with a test signing cert in the certificate store. The build completed and the resulting artifacts inspected for the desired signatures.

## Screenshots (if appropriate):

![Signed Exe](https://user-images.githubusercontent.com/6955786/160583155-6c154c1a-8ae3-4107-b9fe-fa2967ff31a6.png)

![Signed PS1 file](https://user-images.githubusercontent.com/6955786/160583446-26731063-297d-47a0-a0a1-648dbf07fde0.png)

Note that the UnknownError when getting the Authenticode signature of the PS1 file is due to the testing certificate used being selfsigned so the certificate chain isn't trustable.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/chocolatey/boxstarter/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.