### PR TITLE
(doc) Fixed typo in about_boxstarter_bootstrapper

### DIFF
--- a/Boxstarter.Bootstrapper/en-US/about_boxstarter_bootstrapper.help.txt
+++ b/Boxstarter.Bootstrapper/en-US/about_boxstarter_bootstrapper.help.txt
@@ -14,7 +14,7 @@ DESCRIPTION
 ENABLING REBOOTS
 	By default, Boxstarter will not reboot a machine even when
 	Invoke-Reboot is called. In order to enable reboots, either the
-	-RebootOk switch parameter bust be set on Invoke-Boxstarter or
+	-RebootOk switch parameter must be set on Invoke-Boxstarter or
 	the RebootOk $Boxstarter property should be true.
 
 	If Reoots are enabled, calling INVOKE-REBOOT will prepare the


### PR DESCRIPTION
## Description Of Changes
Fixed a typo in about_boxstarter_bootstrapper.help.txt.
Changed `bust` to `must`.

## Motivation and Context
More readable documentation.

## Testing
N/A

## Change Types Made
* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.
* [x] Other: Documentation (non-breaking change)

## Related Issue
N/A (It's a trivial change)

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.