### PR TITLE
(GH-501) Fix Propagation of VerbosePreference to Reduce Verbose Logging

### DIFF
--- a/Boxstarter.Chocolatey/Chocolatey.ps1
+++ b/Boxstarter.Chocolatey/Chocolatey.ps1
@@ -622,7 +622,7 @@ function Export-BoxstarterVars {
 
 function Export-ToEnvironment($varToExport, $scope) {
     $val = Invoke-Expression "`$$($scope):$varToExport"
-    if ($val -is [string] -or $val -is [boolean]) {
+    if ($val -is [string] -or $val -is [boolean] -or $val -is [system.management.automation.actionpreference]) {
         Set-Item -Path "Env:\BEX.$varToExport" -Value $val.ToString() -Force
     }
     elseif ($null -eq $val) {

--- a/Boxstarter.Chocolatey/invoke-chocolatey.ps1
+++ b/Boxstarter.Chocolatey/invoke-chocolatey.ps1
@@ -80,7 +80,7 @@ function Invoke-Chocolatey($chocoArgs) {
                 UseNewEnvironment = $false
                 Wait              = $false
                 WorkingDirectory  = $targetWdir
-                Verbose           = $VerbosePreference
+                Verbose           = ($global:VerbosePreference -eq "Continue")
             }
             
             $p = Start-Process @pargs

--- a/tests/Chocolatey/Chocolatey.tests.ps1
+++ b/tests/Chocolatey/Chocolatey.tests.ps1
@@ -412,6 +412,23 @@ Describe "Call-Chocolatey" {
         }
     }
 
+    context "when not verbose" {
+        $script:passedArgs = ""
+        Mock Invoke-LocalChocolatey { $script:passedArgs = $chocoArgs }
+        $global:VerbosePreference="SilentlyContinue"
+        choco Install pkg
+        $global:VerbosePreference | Should Be "SilentlyContinue"
+
+        it "passes expected params" {
+            $passedArgs.count | Should Be 5
+            $passedArgs[0] | Should Be "Install"
+            $passedArgs[1] | Should Be "pkg"
+            $passedArgs[2] | Should Be "-Source"
+            # $passedArgs[3] -> feeds, may differ from system to system
+            $passedArgs[4] | Should Be "-y"
+        }
+    }
+
     context "when verbose" {
         $script:passedArgs = ""
         Mock Invoke-LocalChocolatey { $script:passedArgs = $chocoArgs }


### PR DESCRIPTION
## Description Of Changes
Updated how `VerbosePreference` was being used to propagate the verbose setting for new `choco.exe` processes and during Boxstarter environment variable restoration.

## Motivation and Context
The `VerbosePreference` parameter was not being set correctly for new `choco.exe` processes as well as when exporting Boxstarter environment variables resulting in verbose output during subprocess Chocolatey package installations.

## Testing
Tested on Windows 11 (21H2 22000.593). Added a new test to check the `-Verbose` parameter is not being set incorrectly. Did not add a test to check for correct environment variable restoration since the test `Export-BoxstarterVars` in `Chocolatey.tests.ps1` failed complete -- likely a scheduled task issue.

## Change Types Made
* [X] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
Fixes #501 

## Change Checklist
* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [X] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

