### PR TITLE
(#508) Fix package iconUrl to be one that Chocolatey owns

### DIFF
--- a/BuildScripts/nuget/Boxstarter.Azure.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Azure.nuspec
@@ -7,7 +7,7 @@
     <owners>Matt Wrock, Rob Reynolds, Gary Ewan Park</owners>
     <copyright>2018 Chocolatey Software, Inc, 2012 - 2018 Matt Wrock</copyright>
     <title>Boxstarter Azure Module</title>
-    <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
+    <iconUrl>https://img.chocolatey.org/logos/boxstarter-logo.png</iconUrl>
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <summary>Azure support for Boxstarter</summary>

--- a/BuildScripts/nuget/Boxstarter.Bootstrapper.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Bootstrapper.nuspec
@@ -7,7 +7,7 @@
     <owners>Matt Wrock, Rob Reynolds, Gary Ewan Park</owners>
     <copyright>2018 Chocolatey Software, Inc, 2012 - 2018 Matt Wrock</copyright>
     <title>Boxstarter Bootstrapper Module</title>
-    <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
+    <iconUrl>https://img.chocolatey.org/logos/boxstarter-logo.png</iconUrl>
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <summary>Bootstrapper module for Boxstarter</summary>

--- a/BuildScripts/nuget/Boxstarter.Chocolatey.nuspec
+++ b/BuildScripts/nuget/Boxstarter.Chocolatey.nuspec
@@ -6,7 +6,7 @@
     <authors>Chocolatey Software, Inc</authors>
     <owners>Matt Wrock, Rob Reynolds, Gary Ewan Park</owners>
     <copyright>2018 Chocolatey Software, Inc, 2012 - 2018 Matt Wrock</copyright>
-    <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
+    <iconUrl>https://img.chocolatey.org/logos/boxstarter-logo.png</iconUrl>
     <title>Boxstarter Chocolatey Module</title>
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>

--- a/BuildScripts/nuget/Boxstarter.HyperV.nuspec
+++ b/BuildScripts/nuget/Boxstarter.HyperV.nuspec
@@ -7,7 +7,7 @@
     <owners>Matt Wrock, Rob Reynolds, Gary Ewan Park</owners>
     <copyright>2018 Chocolatey Software, Inc, 2012 - 2018 Matt Wrock</copyright>
     <title>Boxstarter HyperV Module</title>
-    <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
+    <iconUrl>https://img.chocolatey.org/logos/boxstarter-logo.png</iconUrl>
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <summary>Hyper-V support for Boxstarter</summary>

--- a/BuildScripts/nuget/Boxstarter.TestRunner.nuspec
+++ b/BuildScripts/nuget/Boxstarter.TestRunner.nuspec
@@ -7,7 +7,7 @@
     <owners>Matt Wrock, Rob Reynolds, Gary Ewan Park</owners>
     <copyright>2018 Chocolatey Software, Inc, 2012 - 2018 Matt Wrock</copyright>
     <title>Boxstarter Test Runner Module</title>
-    <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
+    <iconUrl>https://img.chocolatey.org/logos/boxstarter-logo.png</iconUrl>
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <summary>Test runner module for Boxstarter</summary>

--- a/BuildScripts/nuget/Boxstarter.WinConfig.nuspec
+++ b/BuildScripts/nuget/Boxstarter.WinConfig.nuspec
@@ -9,7 +9,7 @@
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <id>Boxstarter.WinConfig</id>
     <title>Boxstarter WinConfig Module</title>
-    <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
+    <iconUrl>https://img.chocolatey.org/logos/boxstarter-logo.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Windows environment module for Boxstarter</summary>
     <packageSourceUrl>https://github.com/chocolatey/boxstarter/</packageSourceUrl>

--- a/BuildScripts/nuget/Boxstarter.nuspec
+++ b/BuildScripts/nuget/Boxstarter.nuspec
@@ -6,7 +6,7 @@
     <authors>Chocolatey Software, Inc</authors>
     <owners>Matt Wrock, Rob Reynolds, Gary Ewan Park</owners>
     <copyright>2018 Chocolatey Software, Inc, 2012 - 2018 Matt Wrock</copyright>
-    <iconUrl>https://cdn.rawgit.com/chocolatey/boxstarter/master/Web/Images/boxLogo_sm.png</iconUrl>
+    <iconUrl>https://img.chocolatey.org/logos/boxstarter-logo.png</iconUrl>
     <title>Boxstarter</title>
     <projectUrl>https://Boxstarter.org</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>


### PR DESCRIPTION
## Description Of Changes
Updated the package iconUrl to be from one that Chocolatey owns.

## Motivation and Context
Icon was pointing to somewhere we had no control over.

## Testing
N/A.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #508 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.