### PR TITLE
(GH-532) Use 'choco install' instead of cinst

### DIFF
--- a/BuildScripts/bootstrapper.ps1
+++ b/BuildScripts/bootstrapper.ps1
@@ -45,11 +45,11 @@ function Get-Boxstarter {
         $chocoVersion  = "2.9.17"
         try {
             New-Object -TypeName Version -ArgumentList $chocoVersion.split('-')[0] | Out-Null
-            $command = "cinst Boxstarter -y"
+            $command = "choco install Boxstarter -y"
         }
         catch{
             # if there is no -v then its an older version with no -y
-            $command = "cinst Boxstarter"
+            $command = "choco install Boxstarter"
         }
         $command += " --version $version"
         Invoke-Expression $command


### PR DESCRIPTION
## Description Of Changes

Fix compatibility with Chocolatey v2 (and the removal of the `cinst` alias)


## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #532 
