### PR TITLE
fix BoxstarterTempDir in Windows

### DIFF
--- a/Boxstarter.Bootstrapper/Get-BoxstarterTempDir.ps1
+++ b/Boxstarter.Bootstrapper/Get-BoxstarterTempDir.ps1
@@ -1,6 +1,6 @@
 function Get-BoxstarterTempDir {
 
-    if ($PSVersionTable.Platform -ne 'Windows') {
+    if ($PSVersionTable.Platform -eq 'Unix') {
         return '/tmp/Boxstarter'
     }
 


### PR DESCRIPTION
$PSVersionTable.Platform is not set in Windows PowerShell - causing TempDir to always be C:/tmp/Boxstarter on Windows.