### PR TITLE
(#548) Remove creation of Chocolatey Install Directory

### DIFF
--- a/Boxstarter.TestRunner/Bootstrap.ps1
+++ b/Boxstarter.TestRunner/Bootstrap.ps1
@@ -2,7 +2,6 @@ function Bootstrap-Boxstarter {
     if(-not $env:ChocolateyInstall -or -not (Test-Path "$env:ChocolateyInstall")){
         Write-Output "Chocolatey not installed. Downloading and installing..."
         $env:ChocolateyInstall = "$env:programdata\chocolatey"
-        New-Item $env:ChocolateyInstall -Force -type directory | Out-Null
         Get-HttpToFile "https://chocolatey.org/install.ps1" "$env:temp\choco.ps1"
         . "$env:temp\choco.ps1"
     }

--- a/BuildScripts/bootstrapper.ps1
+++ b/BuildScripts/bootstrapper.ps1
@@ -82,7 +82,6 @@ function Check-Chocolatey {
             }
             try {
                 $env:ChocolateyInstall = "$env:programdata\chocolatey"
-                New-Item $env:ChocolateyInstall -Force -type directory | Out-Null
                 $url="https://chocolatey.org/api/v2/package/chocolatey/"
                 $wc=new-object net.webclient
                 $wp=[system.net.WebProxy]::GetDefaultProxy()


### PR DESCRIPTION
## Description Of Changes

This commit removes the manal creation of the Chocolatey CLI directory
where the application will be installed to.
This is done as a change in the Chocolatey CLI script have changed so
that if the directory exists, Chocolatey CLI will fail to install.

This manual creation may have been needed some time in the past, but has
not been needed for several years now.

## Motivation and Context

We should not create anything that is not needed to be created, and rely
on the installation script instead to know what to set up for its own
installation.

## Testing

1. Copy the bootstrapper script into a new empty virtual environment without Chocolatey CLI installed.
2. Run `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; . "<PATH_TO_BOOTSTRAPPER>"; Get-Boxstarter -Force` (Replace `<PATH_TO_BOOTSTRAPPER>` with the path to the location you copied the script.
3. Verify Chocolatey CLI and boxstarter was successfully installed.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #548
